### PR TITLE
Granting bot processes high priority, and isolating teams on separate cpus

### DIFF
--- a/agents/java_demo/java_demo_agent.py
+++ b/agents/java_demo/java_demo_agent.py
@@ -9,12 +9,10 @@ try:
         os.path.join(os.getcwd(), os.path.dirname(__file__)))
 
     with open(os.path.join(location, "port.cfg"), "r") as portFile:
-        port = portFile.readline().rstrip()
-
-    int(port)
+        port = int(portFile.readline().rstrip())
 
 except ValueError:
     print("Failed to parse port file!")
     raise
 
-Agent = make_grpc_agent('localhost:' + port)
+Agent = make_grpc_agent('localhost', port)

--- a/bot_manager.py
+++ b/bot_manager.py
@@ -12,23 +12,35 @@ import traceback
 OUTPUT_SHARED_MEMORY_TAG = 'Local\\RLBotOutput'
 INPUT_SHARED_MEMORY_TAG = 'Local\\RLBotInput'
 GAME_TICK_PACKET_REFRESHES_PER_SECOND = 120  # 2*60. https://en.wikipedia.org/wiki/Nyquist_rate
-MAX_AGENT_CALL_PERIOD = timedelta(seconds=1.0/30)  # Minimum call rate when paused.
+MAX_AGENT_CALL_PERIOD = timedelta(seconds=1.0 / 30)  # Minimum call rate when paused.
 REFRESH_IN_PROGRESS = 1
 REFRESH_NOT_IN_PROGRESS = 0
 MAX_CARS = 10
 
 
 class BotManager:
+    def __init__(self, terminate_request_event, termination_complete_event, bot_parameters, name, team, index,
+                 modulename, agent_metadata_queue):
+        """
+        :param terminate_request_event: an Event (multiprocessing) which will be set from the outside when the program is trying to terminate
+        :param termination_complete_event: an Event (multiprocessing) which should be set from inside this class when termination has completed successfully
+        :param bot_parameters: parameters which will be passed to the bot's constructor
+        :param name: name which will be passed to the bot's constructor. Will probably be displayed in-game.
+        :param team: 0 for blue team or 1 for orange team. Will be passed to the bot's constructor.
+        :param index: The player index, i.e. "this is player number <index>". Will be passed to the bot's constructor.
+            Can be used to pull the correct data corresponding to the bot's car out of the game tick packet.
+        :param modulename: The name of the python module which contains the bot's code
+        :param agent_metadata_queue: a Queue (multiprocessing) which expects to receive certain metadata about the agent once available.
+        """
 
-    def __init__(self, terminateEvent, callbackEvent, bot_parameters, name, team, index, modulename, data_queue):
-        self.terminateEvent = terminateEvent
-        self.callbackEvent = callbackEvent
+        self.terminate_request_event = terminate_request_event
+        self.termination_complete_event = termination_complete_event
         self.bot_parameters = bot_parameters
         self.name = name
         self.team = team
         self.index = index
         self.module_name = modulename
-        self.data_queue = data_queue
+        self.agent_metadata_queue = agent_metadata_queue
 
     def load_agent(self, agent_module):
         try:
@@ -36,10 +48,10 @@ class BotManager:
         except TypeError:
             agent = agent_module.Agent(self.name, self.team, self.index)
 
-        self.update_data_queue(agent)
+        self.update_metadata_queue(agent)
         return agent
 
-    def update_data_queue(self, agent):
+    def update_metadata_queue(self, agent):
         pids = set()
         pids.add(os.getpid())
 
@@ -47,7 +59,7 @@ class BotManager:
         if callable(get_extra_pids):
             pids.update(agent.get_extra_pids())
 
-        self.data_queue.put({'index': self.index, 'name': self.name, 'team': self.team, 'pids': pids})
+        self.agent_metadata_queue.put({'index': self.index, 'name': self.name, 'team': self.team, 'pids': pids})
 
     def run(self):
         # Set up shared memory map (offset makes it so bot only writes to its own input!) and map to buffer
@@ -60,8 +72,7 @@ class BotManager:
         game_data_shared_memory = mmap.mmap(-1, ctypes.sizeof(gd.GameTickPacketWithLock), OUTPUT_SHARED_MEMORY_TAG)
         bot_output = gd.GameTickPacketWithLock.from_buffer(game_data_shared_memory)
         lock = ctypes.c_long(0)
-        game_tick_packet = gd.GameTickPacket() # We want to do a deep copy for game inputs so people don't mess with em
-
+        game_tick_packet = gd.GameTickPacket()  # We want to do a deep copy for game inputs so people don't mess with em
 
         # Create Ratelimiter
         r = rate_limiter.RateLimiter(GAME_TICK_PACKET_REFRESHES_PER_SECOND)
@@ -79,17 +90,19 @@ class BotManager:
         agent = self.load_agent(agent_module)
         last_module_modification_time = os.stat(agent_module.__file__).st_mtime
 
-
         # Run until main process tells to stop
-        while not self.terminateEvent.is_set():
+        while not self.terminate_request_event.is_set():
             before = datetime.now()
             # Read from game data shared memory
             game_data_shared_memory.seek(0)  # Move to beginning of shared memory
-            ctypes.memmove(ctypes.addressof(lock), game_data_shared_memory.read(ctypes.sizeof(lock)), ctypes.sizeof(lock)) # dll uses InterlockedExchange so this read will return the correct value!
+            ctypes.memmove(ctypes.addressof(lock), game_data_shared_memory.read(ctypes.sizeof(lock)), ctypes.sizeof(
+                lock))  # dll uses InterlockedExchange so this read will return the correct value!
 
             if lock.value != REFRESH_IN_PROGRESS:
-                game_data_shared_memory.seek(4, os.SEEK_CUR) # Move 4 bytes past error code
-                ctypes.memmove(ctypes.addressof(game_tick_packet), game_data_shared_memory.read(ctypes.sizeof(gd.GameTickPacket)),ctypes.sizeof(gd.GameTickPacket))  # copy shared memory into struct
+                game_data_shared_memory.seek(4, os.SEEK_CUR)  # Move 4 bytes past error code
+                ctypes.memmove(ctypes.addressof(game_tick_packet),
+                               game_data_shared_memory.read(ctypes.sizeof(gd.GameTickPacket)),
+                               ctypes.sizeof(gd.GameTickPacket))  # copy shared memory into struct
 
             # Run the Agent only if the gameInfo has updated.
             tick_game_time = game_tick_packet.gameInfo.TimeSeconds
@@ -110,7 +123,6 @@ class BotManager:
                         # Retire after the replacement initialized properly.
                         if hasattr(old_agent, 'retire'):
                             old_agent.retire()
-
 
                     # Call agent
                     controller_input = agent.get_output_vector(game_tick_packet)
@@ -138,9 +150,9 @@ class BotManager:
             # Ratelimit here
             after = datetime.now()
             # print('Latency of ' + self.name + ': ' + str(after - before))
-            r.acquire(after-before)
+            r.acquire(after - before)
 
         if hasattr(agent, 'retire'):
             agent.retire()
         # If terminated, send callback
-        self.callbackEvent.set()
+        self.termination_complete_event.set()

--- a/grpcsupport/grpc_client.py
+++ b/grpcsupport/grpc_client.py
@@ -7,7 +7,7 @@ from .protobuf import game_data_pb2_grpc
 
 
 def make_grpc_agent(address, port):
-    '''
+    """
         parameters:
             address - address for grpc connection. example: `localhost`
             port - port for grpc connection. example: 34865
@@ -16,7 +16,7 @@ def make_grpc_agent(address, port):
             grpc server and returns its response.
 
         For an example use of this, see: agents/java_demo
-    '''
+    """
     server_address = address + ':' + str(port)
 
     class GrpcForwardingAgent:

--- a/grpcsupport/grpc_client.py
+++ b/grpcsupport/grpc_client.py
@@ -1,19 +1,23 @@
 import grpc
 import time
+import msvcrt
+import psutil
 from . import proto_converter
 from .protobuf import game_data_pb2_grpc
 
 
-def make_grpc_agent(server_address):
+def make_grpc_agent(address, port):
     '''
         parameters:
-            server_address - grpc target string. example: 'localhost:34865'
+            address - address for grpc connection. example: `localhost`
+            port - port for grpc connection. example: 34865
         returns:
             A RLBot Agent class which forwards the game_tick_packet to the
             grpc server and returns its response.
 
         For an example use of this, see: agents/java_demo
     '''
+    server_address = address + ':' + str(port)
 
     class GrpcForwardingAgent:
         def __init__(self, name, team, index):
@@ -28,6 +32,17 @@ def make_grpc_agent(server_address):
             except Exception as e:
                 print("Exception when trying to connect to grpc server: " + str(e))
                 pass
+
+        def get_extra_pids(self):
+            while True:
+                if msvcrt.kbhit():
+                    return []
+                for proc in psutil.process_iter():
+                    for conn in proc.connections():
+                        if conn.laddr.port == port:
+                            print('gRPC server for {} appears to have pid {}'.format(self.name, proc.pid))
+                            return [proc.pid]
+                time.sleep(1)
 
         def init_protobuf(self):
             print("Connecting to grpc server: " + server_address)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+psutil
+grpcio

--- a/rlbot.cfg
+++ b/rlbot.cfg
@@ -7,7 +7,7 @@ num_participants = 2
 # Everything needs a config, even players and default bots.  We still set loadouts and names from config!
 participant_config_0 = ./agents/atba/atba.cfg
 # e.g. Could use       ./agents/java_demo/java_demo_agent.cfg
-participant_config_1 = ./agents/atba/atba.cfg
+participant_config_1 = ./agents/java_demo/java_demo_agent.cfg
 participant_config_2 = ./agents/atba/atba.cfg
 participant_config_3 = ./agents/atba/atba.cfg
 participant_config_4 = ./agents/atba/atba.cfg

--- a/rlbot.cfg
+++ b/rlbot.cfg
@@ -7,7 +7,7 @@ num_participants = 2
 # Everything needs a config, even players and default bots.  We still set loadouts and names from config!
 participant_config_0 = ./agents/atba/atba.cfg
 # e.g. Could use       ./agents/java_demo/java_demo_agent.cfg
-participant_config_1 = ./agents/java_demo/java_demo_agent.cfg
+participant_config_1 = ./agents/atba/atba.cfg
 participant_config_2 = ./agents/atba/atba.cfg
 participant_config_3 = ./agents/atba/atba.cfg
 participant_config_4 = ./agents/atba/atba.cfg

--- a/runner.py
+++ b/runner.py
@@ -5,12 +5,14 @@ import ctypes
 import game_data_struct as gd
 import mmap
 import multiprocessing as mp
+import queue
 import msvcrt
 import rlbot_exception
 import time
 import os
 import sys
 import subprocess
+import psutil
 
 PARTICPANT_CONFIGURATION_HEADER = 'Participant Configuration'
 PARTICPANT_BOT_KEY_PREFIX = 'participant_is_bot_'
@@ -48,11 +50,11 @@ def get_sanitized_bot_name(dict, name):
     return new_name
 
 
-def run_agent(terminate_event, callback_event, config_file, name, team, index, module_name):
+def run_agent(terminate_event, callback_event, config_file, name, team, index, module_name, shared_dict):
     bm = bot_manager.BotManager(terminate_event, callback_event, config_file, name, team,
-                                index, module_name)
+                                index, module_name, shared_dict)
     bm.run()
-    
+
 def injectDLL():
     """
     Calling thid function will inject the DLL with as 'hidden'
@@ -72,12 +74,12 @@ def injectDLL():
         return injection_status
     else:
         sys.exit()
-    
+
 
 def main():
-    # Inject DLL, fails if 
+    # Inject DLL, fails if
     injectDLL()
-    
+
     # Set up RLBot.cfg
     framework_config = configparser.RawConfigParser()
     framework_config.read(RLBOT_CONFIG_FILE)
@@ -164,6 +166,9 @@ def main():
     # Create Quit event
     quit_event = mp.Event()
 
+    all_bot_data = {}
+    bot_data_queue = mp.Queue()
+
     # Launch processes
     for i in range(num_participants):
         if gameInputPacket.sPlayerConfiguration[i].bRLBotControlled:
@@ -172,7 +177,7 @@ def main():
             process = mp.Process(target=run_agent,
                                  args=(quit_event, callback, bot_parameter_list[i],
                                        str(gameInputPacket.sPlayerConfiguration[i].wName),
-                                       bot_teams[i], i, bot_modules[i]))
+                                       bot_teams[i], i, bot_modules[i], bot_data_queue))
             process.start()
 
     print("Successfully configured bots. Setting flag for injected dll.")
@@ -194,7 +199,18 @@ def main():
         raise rlbot_exception.RLBotException().raise_exception_from_error_code(bot_output.iLastError)
 
     print("Press any character to exit")
-    msvcrt.getch()
+    while True:
+        if msvcrt.kbhit():
+            break
+        try:
+            bot_data = bot_data_queue.get(timeout=1)
+            all_bot_data[bot_data['index']] = bot_data
+            configure_processes(all_bot_data)
+        except queue.Empty:
+            pass
+        except Exception as ex:
+            print(ex)
+            pass
 
     print("Shutting Down")
     quit_event.set()
@@ -206,6 +222,49 @@ def main():
             if not callback.is_set():
                 terminated = False
 
+
+def configure_processes(bot_data_dict):
+    team_pids_map = {}
+
+    for player_index, data in bot_data_dict.items():
+        team = data['team']
+        if not team in team_pids_map:
+            team_pids_map[team] = set()
+        team_pids_map[team].update(data['pids'])
+
+    shared_pids = set()
+    cpu_count = psutil.cpu_count()
+    cpus_per_team = cpu_count // 3
+
+    if len(team_pids_map) >= 2 and cpus_per_team > 0:
+        # Sort into three sets of pids: team 0 exclusives, team 1 exclusives, and shared pids
+        # All pids will be assigned high priority
+        # Team exclusive pids will be bound to a subset of cpus so they can't adversely affect the opposite team.
+
+        for team, team_set in team_pids_map.items():
+            if not shared_pids:
+                shared_pids.update(team_set)
+            else:
+                shared_pids.intersection_update(team_set)
+
+        for team, team_set in team_pids_map.items():
+            team_set -= shared_pids
+
+        for team, team_pids in team_pids_map.items():
+            team_cpu_offset = cpus_per_team * team
+            team_cpus = list(range(cpu_count - cpus_per_team - team_cpu_offset, cpu_count - team_cpu_offset))
+            for pid in team_pids:
+                p = psutil.Process(pid)
+                p.cpu_affinity(team_cpus)  # Restrict the process to run on the cpus assigned to the team
+                p.nice(psutil.HIGH_PRIORITY_CLASS)  # Allow the process to run at high priority
+    else:
+        # Consider everything a shared pid, because we are not in a position to split up cpus.
+        for team, team_set in team_pids_map.items():
+            shared_pids.update(team_set)
+
+    for pid in shared_pids:
+        p = psutil.Process(pid)  # Allow the process to run at high priority
+        p.nice(psutil.HIGH_PRIORITY_CLASS)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This will hopefully prevent CPU hogging bots from affecting their opponents.
The process priority increase should help everybody.

This includes a breaking change to grpc_client.py: You now need to call make_grpc_agent with address and port as separate params. I don't think many people are using it yet, so I'm willing to dry any and all tears.

This also requires the installation of psutil via `pip install psutil`, so we would have to update the setup instructions.