### PR TITLE
Adding framework support for java bots that communicate directly with dll.

### DIFF
--- a/RLBotFramework/agents/base_independent_agent.py
+++ b/RLBotFramework/agents/base_independent_agent.py
@@ -1,6 +1,4 @@
 from RLBotFramework.agents.base_agent import BaseAgent
-from RLBotFramework.grpcsupport.protobuf import game_data_pb2
-
 
 class BaseIndependentAgent(BaseAgent):
     """

--- a/src/main/java/rlbot/Bot.java
+++ b/src/main/java/rlbot/Bot.java
@@ -1,0 +1,12 @@
+package rlbot;
+
+import rlbot.api.GameData;
+
+public interface Bot {
+
+    int getIndex();
+
+    GameData.ControllerState processInput(GameData.GameTickPacket request);
+
+    void retire();
+}

--- a/src/main/java/rlbot/cpp/ByteBufferStruct.java
+++ b/src/main/java/rlbot/cpp/ByteBufferStruct.java
@@ -1,0 +1,20 @@
+package rlbot.cpp;
+
+import com.sun.jna.Pointer;
+import com.sun.jna.Structure;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class ByteBufferStruct extends Structure implements Structure.ByValue {
+
+    private static final List<String> fields = Arrays.asList("ptr", "size");
+
+    public Pointer ptr;
+    public int size;
+
+    @Override
+    protected List<String> getFieldOrder() {
+        return fields;
+    }
+}

--- a/src/main/java/rlbot/cpp/RLBotDll.java
+++ b/src/main/java/rlbot/cpp/RLBotDll.java
@@ -1,0 +1,38 @@
+package rlbot.cpp;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.sun.jna.Memory;
+import com.sun.jna.Native;
+import com.sun.jna.Pointer;
+import rlbot.api.GameData;
+
+public class RLBotDll {
+
+    private static native ByteBufferStruct UpdateLiveDataPacketProto();
+    private static native int UpdatePlayerInputProto(Pointer ptr, int size, int playerIndex);
+
+    static {
+        Native.register("RLBot_Core_Interface");
+    }
+
+    public static GameData.GameTickPacket getProtoPacket() throws InvalidProtocolBufferException {
+        ByteBufferStruct struct = UpdateLiveDataPacketProto();
+        byte[] protoBytes = struct.ptr.getByteArray(0, struct.size);
+        GameData.GameTickPacket packet = GameData.GameTickPacket.parseFrom(protoBytes);
+
+        return packet;
+    }
+
+    public static void setControllerState(GameData.ControllerState controllerState, int playerIndex) {
+        byte[] protoBytes = controllerState.toByteArray();
+        Memory memory = getMemory(protoBytes);
+        UpdatePlayerInputProto(memory, protoBytes.length, playerIndex);
+    }
+
+    private static Memory getMemory(byte[] protoBytes) {
+        final Memory mem = new Memory(protoBytes.length);
+        mem.write(0, protoBytes, 0, protoBytes.length);
+        return mem;
+    }
+
+}

--- a/src/main/java/rlbot/manager/BotManager.java
+++ b/src/main/java/rlbot/manager/BotManager.java
@@ -1,0 +1,86 @@
+package rlbot.manager;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import rlbot.Bot;
+import rlbot.api.GameData;
+import rlbot.cpp.RLBotDll;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class BotManager {
+
+    private final Map<Integer, BotProcess> botProcesses = new HashMap<>();
+
+    private boolean keepRunning;
+
+    private final Object dinnerBell = new Object();
+    private  GameData.GameTickPacket latestPacket;
+
+    public void registerBot(final int index, final Bot bot) {
+        if (botProcesses.containsKey(index)) {
+            return;
+        }
+
+        botProcesses.computeIfAbsent(index, (idx) -> {
+            Thread botThread = new Thread(() -> doRunBot(bot));
+            botThread.start();
+            return new BotProcess(bot, botThread);
+        });
+    }
+
+    private void doRunBot(Bot bot) {
+        while (keepRunning) {
+            try {
+                synchronized (dinnerBell) {
+                    dinnerBell.wait(1000);
+                }
+                GameData.ControllerState controllerState = bot.processInput(latestPacket);
+                RLBotDll.setControllerState(controllerState, bot.getIndex());
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+        bot.retire();
+    }
+
+    private void retireBots() {
+        botProcesses.clear();
+    }
+
+    public void start() {
+        if (keepRunning) {
+            return; // Already started
+        }
+
+        keepRunning = true;
+        Thread looper = new Thread(this::doLoop);
+        looper.start();
+    }
+
+    private void doLoop() {
+        while (keepRunning) {
+
+            try {
+                latestPacket = RLBotDll.getProtoPacket();
+                synchronized (dinnerBell) {
+                    dinnerBell.notifyAll();
+                }
+
+            } catch (InvalidProtocolBufferException e) {
+                e.printStackTrace();
+            }
+
+            try {
+                Thread.sleep(16);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public void retire() {
+        keepRunning = false;
+        retireBots();
+    }
+}

--- a/src/main/java/rlbot/manager/BotProcess.java
+++ b/src/main/java/rlbot/manager/BotProcess.java
@@ -1,0 +1,21 @@
+package rlbot.manager;
+
+import rlbot.Bot;
+
+public class BotProcess {
+    private Bot bot;
+    private Thread thread;
+
+    public BotProcess(Bot bot, Thread thread) {
+        this.bot = bot;
+        this.thread = thread;
+    }
+
+    public Bot getBot() {
+        return bot;
+    }
+
+    public Thread getThread() {
+        return thread;
+    }
+}

--- a/src/main/java/rlbot/py/PythonInterface.java
+++ b/src/main/java/rlbot/py/PythonInterface.java
@@ -1,0 +1,10 @@
+package rlbot.py;
+
+/**
+ * The public methods of implementing classes will be called directly from the python component of the RLBot framework.
+ *
+ * This interface currently has no methods because bots should have control over their python-java interface,
+ * it's just here to provide guidance.
+ */
+public interface PythonInterface {
+}

--- a/src/main/java/rlbot/py/PythonServer.java
+++ b/src/main/java/rlbot/py/PythonServer.java
@@ -1,0 +1,27 @@
+package rlbot.py;
+
+import py4j.GatewayServer;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public class PythonServer {
+
+    private final Object pythonInterface;
+    private final Integer port;
+
+    public PythonServer(PythonInterface pythonInterface, Integer port) {
+        this.pythonInterface = pythonInterface;
+        this.port = port;
+    }
+
+    public void start() {
+        GatewayServer gatewayServer = new GatewayServer(pythonInterface, port);
+        gatewayServer.start();
+        System.out.println(String.format("Gateway server started on port %s. Listening for commands!", port));
+    }
+}


### PR DESCRIPTION
Later, we can use gradle to compile this into a jar, and include the jar in a maven publication. Java bots will be able to pull in this code as a dependency. Easy for them, and more control for us in terms of fairness and vending updates.

I've successfully tested this in-game.