### PR TITLE
Don't run pip during build. Removing useless line in gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,8 +116,6 @@ ENV/
 # Gradle
 .gradle
 
-apikey
-
 # Generated integration test data
 /src/test/python/integration_test/history.pb.bin
 

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,6 @@ task pipInstallRequirements(type: Exec) {
 
 // Establish some task dependencies so that some tasks always run before others.
 // processResources is a task built in to the java plugin that runs early on during a build.
-processResources.dependsOn pipInstallRequirements
 processResources.dependsOn assembleProto
 
 // This task creates a jar file which contains the java source files.


### PR DESCRIPTION
Running pip during the build is unnecessary, plus jitpack can't handle it:
https://jitpack.io/com/github/RLBot/RLBot/0.0.1/build.log

The pipInstallRequirements task can still be used directly if desired.