### PR TITLE
Fixing full boost detection in java demo bot.

### DIFF
--- a/agents/java_demo/src/rlbot/input/FullBoost.java
+++ b/agents/java_demo/src/rlbot/input/FullBoost.java
@@ -1,11 +1,11 @@
 package rlbot.input;
 
 
+import rlbot.vector.Vector2;
 import rlbot.vector.Vector3;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 
 public class FullBoost {
 
@@ -13,13 +13,13 @@ public class FullBoost {
     private static final int CORNER_BOOST_WIDTH = 3072;
     private static final int CORNER_BOOST_DEPTH = 4096;
 
-    private static final List<Vector3> fullBoostLocations = Arrays.asList(
-            new Vector3(MIDFIELD_BOOST_WIDTH, 0, 0),
-            new Vector3(-MIDFIELD_BOOST_WIDTH, 0, 0),
-            new Vector3(-CORNER_BOOST_WIDTH, -CORNER_BOOST_DEPTH, 0),
-            new Vector3(-CORNER_BOOST_WIDTH, CORNER_BOOST_DEPTH, 0),
-            new Vector3(CORNER_BOOST_WIDTH, -CORNER_BOOST_DEPTH, 0),
-            new Vector3(CORNER_BOOST_WIDTH, CORNER_BOOST_DEPTH, 0)
+    private static final List<Vector2> fullBoostLocations = Arrays.asList(
+            new Vector2(MIDFIELD_BOOST_WIDTH, 0),
+            new Vector2(-MIDFIELD_BOOST_WIDTH, 0),
+            new Vector2(-CORNER_BOOST_WIDTH, -CORNER_BOOST_DEPTH),
+            new Vector2(-CORNER_BOOST_WIDTH, CORNER_BOOST_DEPTH),
+            new Vector2(CORNER_BOOST_WIDTH, -CORNER_BOOST_DEPTH),
+            new Vector2(CORNER_BOOST_WIDTH, CORNER_BOOST_DEPTH)
     );
 
     public Vector3 location;
@@ -31,8 +31,8 @@ public class FullBoost {
     }
 
     public static boolean isFullBoostLocation(Vector3 location) {
-        for (Vector3 boostLoc: fullBoostLocations) {
-            if (boostLoc.distance(location) < 10) {
+        for (Vector2 boostLoc: fullBoostLocations) {
+            if (boostLoc.distance(location.flatten()) < 10) {
                 return true;
             }
         }


### PR DESCRIPTION
Psyonix moved the boost pads up from z=0 to z=64. Good prank.