### PR TITLE
Adding a contains_locked_file utility

### DIFF
--- a/src/main/python/rlbot/gui/preset_editors.py
+++ b/src/main/python/rlbot/gui/preset_editors.py
@@ -6,7 +6,7 @@ import configparser
 from rlbot.gui.design.car_customisation import Ui_LoadoutPresetCustomiser
 from rlbot.gui.design.agent_customisation import Ui_AgentPresetCustomiser
 from rlbot.gui.presets import AgentPreset, LoadoutPreset
-from rlbot.utils.class_importer import get_python_root
+from rlbot.utils.file_util import get_python_root
 
 
 class BasePresetEditor(QtWidgets.QWidget):

--- a/src/main/python/rlbot/gui/presets.py
+++ b/src/main/python/rlbot/gui/presets.py
@@ -4,7 +4,8 @@ import configparser
 
 from rlbot.agents.base_agent import BaseAgent
 from rlbot.agents.base_agent import PYTHON_FILE_KEY, BOT_CONFIG_MODULE_HEADER
-from rlbot.utils.class_importer import import_agent, get_python_root
+from rlbot.utils.class_importer import import_agent
+from rlbot.utils.file_util import get_python_root
 
 
 class Preset:

--- a/src/main/python/rlbot/gui/qt_root.py
+++ b/src/main/python/rlbot/gui/qt_root.py
@@ -17,7 +17,7 @@ from rlbot.gui.design.qt_gui import Ui_MainWindow
 from rlbot.gui.gui_agent import GUIAgent
 from rlbot.gui.preset_editors import CarCustomisationDialog, AgentCustomisationDialog
 
-from rlbot.utils.class_importer import get_python_root
+from rlbot.utils.file_util import get_python_root
 from rlbot.agents.base_agent import BOT_CONFIG_MODULE_HEADER, BOT_NAME_KEY
 from rlbot.setup_manager import SetupManager, DEFAULT_RLBOT_CONFIG_LOCATION
 

--- a/src/main/python/rlbot/utils/class_importer.py
+++ b/src/main/python/rlbot/utils/class_importer.py
@@ -82,7 +82,3 @@ def extract_class(containing_module, base_class):
 
     return valid_classes[0]
 
-
-def get_python_root():
-    """Gets the path of the RLBot directory"""
-    return os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))

--- a/src/main/python/rlbot/utils/file_util.py
+++ b/src/main/python/rlbot/utils/file_util.py
@@ -1,0 +1,29 @@
+import os
+
+
+def get_python_root() -> str:
+    """Gets the path of the python root directory that rlbot lives in."""
+    return os.path.dirname(get_rlbot_directory())
+
+
+def get_rlbot_directory() -> str:
+    """Gets the path of the rlbot package directory"""
+    return os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+
+
+def contains_locked_file(directory: str):
+    """
+    Avoid moving or renaming this! It is considered part of the API of this package.
+    :return: True if any of the files in the directory are in use. For example, if the dll is injected
+    into the game, this will definitely return true.
+    """
+    for root, subdirs, files in os.walk(directory):
+        for filename in files:
+            file_path = os.path.join(root, filename)
+            try:
+                with open(file_path, 'a'):
+                    pass
+            except IOError:
+                print(file_path)
+                return True
+    return False

--- a/src/main/python/rlbot/utils/structures/game_interface.py
+++ b/src/main/python/rlbot/utils/structures/game_interface.py
@@ -5,7 +5,7 @@ import sys
 import time
 
 from rlbot.utils.rendering.rendering_manager import RenderingManager
-from rlbot.utils.class_importer import get_python_root
+from rlbot.utils.file_util import get_python_root
 from rlbot.utils.structures.bot_input_struct import PlayerInput
 from rlbot.utils.structures.game_data_struct import GameTickPacket, ByteBuffer, FieldInfoPacket
 from rlbot.utils.structures.game_status import RLBotCoreStatus

--- a/src/test/bat/can_update.bat
+++ b/src/test/bat/can_update.bat
@@ -1,0 +1,15 @@
+pushd ..\..\main\python
+
+python -c "from rlbot.utils import file_util; print(file_util.contains_locked_file(file_util.get_rlbot_directory()));" > ^
+%temp%\is_locked.txt
+
+set /p is_locked= < %temp%\is_locked.txt
+del %temp%\is_locked.txt
+
+IF "%is_locked%"=="False" (
+    ECHO can update rlbot!
+) ELSE (
+    ECHO cannot update rlbot!
+)
+
+popd


### PR DESCRIPTION
This will allow us to fix https://github.com/RLBot/RLBot/issues/130

I decided to move get_python_root to a new file, partly because the class_importer module can't be imported without sys.path hacking, making it a pain in the ass for this purpose.