### PR TITLE
GUI update fixing off-disk rlbot.cfg and remove controller_passthrough

### DIFF
--- a/src/main/python/rlbot/gui/design/qt_gui.py
+++ b/src/main/python/rlbot/gui/design/qt_gui.py
@@ -2,7 +2,7 @@
 
 # Form implementation generated from reading ui file 'qt_gui.ui'
 #
-# Created by: PyQt5 UI code generator 5.10.1
+# Created by: PyQt5 UI code generator 5.11
 #
 # WARNING! All changes made in this file will be lost!
 
@@ -171,7 +171,6 @@ class Ui_MainWindow(object):
         self.horizontalLayout_2.addWidget(self.label)
         self.bot_type_combobox = QtWidgets.QComboBox(self.frame)
         self.bot_type_combobox.setObjectName("bot_type_combobox")
-        self.bot_type_combobox.addItem("")
         self.bot_type_combobox.addItem("")
         self.bot_type_combobox.addItem("")
         self.bot_type_combobox.addItem("")
@@ -469,7 +468,6 @@ class Ui_MainWindow(object):
         self.bot_type_combobox.setItemText(1, _translate("MainWindow", "Psyonix"))
         self.bot_type_combobox.setItemText(2, _translate("MainWindow", "RLBot"))
         self.bot_type_combobox.setItemText(3, _translate("MainWindow", "Party Member Bot"))
-        self.bot_type_combobox.setItemText(4, _translate("MainWindow", "Controller Passthrough"))
         self.blue_radiobutton.setText(_translate("MainWindow", "Blue"))
         self.orange_radiobutton.setText(_translate("MainWindow", "Orange"))
         self.label_3.setText(_translate("MainWindow", "IGN:"))

--- a/src/main/python/rlbot/gui/design/qt_gui.ui
+++ b/src/main/python/rlbot/gui/design/qt_gui.ui
@@ -409,11 +409,6 @@
                  <string>Party Member Bot</string>
                 </property>
                </item>
-               <item>
-                <property name="text">
-                 <string>Controller Passthrough</string>
-                </property>
-               </item>
               </widget>
              </item>
             </layout>

--- a/src/main/python/rlbot/gui/qt_root.py
+++ b/src/main/python/rlbot/gui/qt_root.py
@@ -21,6 +21,7 @@ from rlbot.setup_manager import SetupManager, DEFAULT_RLBOT_CONFIG_LOCATION
 from rlbot.parsing.rlbot_config_parser import create_bot_config_layout, TEAM_CONFIGURATION_HEADER
 from rlbot.parsing.agent_config_parser import PARTICIPANT_CONFIGURATION_HEADER, PARTICIPANT_LOADOUT_CONFIG_KEY, LOOKS_CONFIG_KEY
 from rlbot.parsing.match_settings_config_parser import *
+from rlbot.parsing.custom_config import ConfigObject
 
 
 class RLBotQTGui(QMainWindow, Ui_MainWindow):
@@ -51,10 +52,7 @@ class RLBotQTGui(QMainWindow, Ui_MainWindow):
         if os.path.isfile(DEFAULT_RLBOT_CONFIG_LOCATION):
             self.load_overall_config(DEFAULT_RLBOT_CONFIG_LOCATION)
         else:
-            self.load_overall_config("")
-            self.frame_3.setDisabled(True)
-            self.match_settings_groupbox.setDisabled(True)
-            self.cfg_save_pushbutton.setDisabled(True)
+            self.load_off_disk_overall_config()
 
         self.init_match_settings()
         self.update_match_settings()
@@ -268,6 +266,19 @@ class RLBotQTGui(QMainWindow, Ui_MainWindow):
         self.blue_color_spinbox.setValue(self.overall_config.getint(TEAM_CONFIGURATION_HEADER, "Team Blue Color"))
         self.orange_color_spinbox.setValue(self.overall_config.getint(TEAM_CONFIGURATION_HEADER, "Team Orange Color"))
 
+    def load_off_disk_overall_config(self):
+        if self.overall_config is None:
+            self.overall_config = create_bot_config_layout()
+        GUIAgent.overall_config = self.overall_config
+        self.overall_config.init_indices(10)
+        self.overall_config_path = ""
+        self.load_agents()
+        self.update_teams_listwidgets()
+        self.cfg_file_path_lineedit.setText(self.overall_config_path)
+        self.update_team_settings()
+        self.car_customisation.update_presets_widgets()
+        self.agent_customisation.update_presets_widgets()
+
     def load_overall_config(self, config_path=None):
         """
         Loads the overall config from the config path, or asks for a path if config_path is None
@@ -293,8 +304,6 @@ class RLBotQTGui(QMainWindow, Ui_MainWindow):
             if not raw_parser.has_section(section):
                 self.popup_message("Config file is missing the section {}, not loading it!".format(section), "Invalid Config File", QMessageBox.Warning)
                 return
-        for item in (self.frame_3, self.match_settings_groupbox, self.cfg_save_pushbutton):
-            item.setEnabled(True)
         self.overall_config_path = config_path
         self.overall_config.parse_file(raw_parser, 10)
         self.load_agents()
@@ -535,8 +544,6 @@ class RLBotQTGui(QMainWindow, Ui_MainWindow):
                 self.orange_listwidget.setCurrentRow(self.orange_listwidget.count() - 1)
             else:
                 self.blue_listwidget.setCurrentRow(self.blue_listwidget.count() - 1)
-
-
 
     def add_loadout_preset(self, file_path: str):
         """

--- a/src/main/python/rlbot/gui/qt_root.py
+++ b/src/main/python/rlbot/gui/qt_root.py
@@ -231,7 +231,7 @@ class RLBotQTGui(QMainWindow, Ui_MainWindow):
             self.psyonix_bot_frame.setHidden(False)
             self.rlbot_frame.setHidden(True)
             self.extra_line.setHidden(False)
-        elif self.bot_type_combobox.currentText() == 'Human' or self.bot_type_combobox.currentText() == 'Party Member Bot' or self.bot_type_combobox.currentText() == 'Controller Passthrough':
+        elif self.bot_type_combobox.currentText() == 'Human' or self.bot_type_combobox.currentText() == 'Party Member Bot':
             self.psyonix_bot_frame.setHidden(True)
             self.rlbot_frame.setHidden(True)
             self.extra_line.setHidden(True)
@@ -362,7 +362,7 @@ class RLBotQTGui(QMainWindow, Ui_MainWindow):
         # load the bot parameters into the edit frame
         agent_type = agent.get_participant_type()
 
-        known_types = ['human', 'psyonix', 'rlbot', 'party_member_bot', 'controller_passthrough']
+        known_types = ['human', 'psyonix', 'rlbot', 'party_member_bot']
         assert agent_type in known_types, 'Bot has unknown type: %s' % agent_type
 
         self.bot_type_combobox.setCurrentIndex(known_types.index(agent_type))

--- a/src/main/python/rlbot/parsing/agent_config_parser.py
+++ b/src/main/python/rlbot/parsing/agent_config_parser.py
@@ -43,15 +43,14 @@ def add_participant_header(config_object):
                                              "team 1 (orange) shoots on negative goal")
 
     participant_header.add_value(PARTICIPANT_TYPE_KEY, str, default='rlbot',
-                                 description="""Accepted values are "human", "rlbot", "psyonix", "party_member_bot", and "controller_passthrough"
+                                 description="""Accepted values are "human", "rlbot", "psyonix" and "party_member_bot"
                                              You can have up to 4 local players and they must 
                                              be activated in game or it will crash.
                                              If no player is specified you will be spawned in as spectator!
                                              human - not controlled by the framework
                                              rlbot - controlled by the framework
                                              psyonix - default bots (skill level can be changed with participant_bot_skill
-                                             party_member_bot - controlled by an rlbot but the game detects it as a human
-                                             controller_passthrough - controlled by a human but runs through the framework""")
+                                             party_member_bot - controlled by an rlbot but the game detects it as a human""")
 
     participant_header.add_value(PARTICIPANT_BOT_SKILL_KEY, float, default=1.0,
                                  description='If participant is a bot and not RLBot controlled,' +
@@ -139,18 +138,13 @@ def get_bot_options(bot_type):
     elif bot_type == 'psyonix':
         is_bot = True
         is_rlbot = False
-    elif bot_type == 'controller_passthrough':
-        # this is an rlbot but a very specific rlbot
-        is_bot = True
-        is_rlbot = True
     elif bot_type == 'party_member_bot':
         # this is a bot running under a human
 
         is_rlbot = True
         is_bot = False
     else:
-        raise ValueError('participant_type value is not "human", "rlbot", "psyonix", ' +
-                         '"party_member_bot", or "controller_passthrough"')
+        raise ValueError('participant_type value is not "human", "rlbot", "psyonix" or "party_member_bot"')
 
     return is_bot, is_rlbot
 


### PR DESCRIPTION
The first commit removes controller passthrough from the list with options, since it was not an available feature and will not be implemented.
The second commit should add the ability to load the GUI even when rlbot.cfg is not on disk.