### PR TITLE
Generate flatbuffers via a batch file during VS build.

### DIFF
--- a/src/main/cpp/RLBotInterface/RLBotMessages/RLBotMessages.vcxproj
+++ b/src/main/cpp/RLBotInterface/RLBotMessages/RLBotMessages.vcxproj
@@ -222,7 +222,7 @@
       <VerboseOutput>false</VerboseOutput>
     </Manifest>
     <PreBuildEvent>
-      <Command>$(FlatbufferSrcDir)\flatc.exe --cpp -o $(FlatbufferDir) $(FlatbufferSrcDir)\rlbot.fbs</Command>
+      <Command>"$(ProjectDir)\generate-flatbuffers.bat"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -296,7 +296,7 @@
       <VerboseOutput>false</VerboseOutput>
     </Manifest>
     <PreBuildEvent>
-      <Command>$(FlatbufferSrcDir)\flatc.exe --cpp -o $(FlatbufferDir) $(FlatbufferSrcDir)\rlbot.fbs</Command>
+      <Command>"$(ProjectDir)\generate-flatbuffers.bat"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -361,7 +361,7 @@
       </Command>
     </PostBuildEvent>
     <PreBuildEvent>
-      <Command>$(FlatbufferSrcDir)\flatc.exe --cpp -o $(FlatbufferDir) $(FlatbufferSrcDir)\rlbot.fbs</Command>
+      <Command>"$(ProjectDir)\generate-flatbuffers.bat"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -426,7 +426,7 @@
       </Command>
     </PostBuildEvent>
     <PreBuildEvent>
-      <Command>$(FlatbufferSrcDir)\flatc.exe --cpp -o $(FlatbufferDir) $(FlatbufferSrcDir)\rlbot.fbs</Command>
+      <Command>"$(ProjectDir)\generate-flatbuffers.bat"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/src/main/cpp/RLBotInterface/RLBotMessages/generate-flatbuffers.bat
+++ b/src/main/cpp/RLBotInterface/RLBotMessages/generate-flatbuffers.bat
@@ -1,0 +1,11 @@
+@rem Change the working directory to the location of this file so that relative paths will work
+
+pushd "%~dp0"
+
+echo Generating flatbuffers header file...
+
+..\..\..\flatbuffers\flatc.exe --cpp -o ..\..\..\..\generated\cpp\flatbuffers ..\..\..\flatbuffers\rlbot.fbs
+
+echo Done.
+
+popd


### PR DESCRIPTION
This will probably work better for people with spaces in their folder path.