### PR TITLE
removed has_values from configheader

### DIFF
--- a/src/main/python/rlbot/parsing/custom_config.py
+++ b/src/main/python/rlbot/parsing/custom_config.py
@@ -101,8 +101,8 @@ class ConfigObject:
         return new_object
 
     def has_section(self, header_name):
-        """Returns true if the header exist and has had at least one value set on it."""
-        return header_name in self.headers and self.headers[header_name].has_values
+        """Returns true if the header exists"""
+        return header_name in self.headers
 
     def get_raw_file(self):
         """Returns the raw file from the parser so it can be used to be parsed by other config objects."""
@@ -114,7 +114,6 @@ class ConfigHeader:
     def __init__(self):
         self.values = {}
         self.is_indexed = False  # if True then indexes will be applied to all values otherwise they will not be
-        self.has_values = False  # False if no values have been set on this header object.
         self.max_index = -1
 
     def __getitem__(self, x):
@@ -134,8 +133,6 @@ class ConfigHeader:
             description = name
         if value is not None and self.is_indexed and not isinstance(value, list):
             raise Exception('Indexed values must be a list')
-        if value is not None:
-            self.has_values = True
         self.values[name] = ConfigValue(value_type, default=default, description=description, value=value)
         return self
 
@@ -155,7 +152,6 @@ class ConfigHeader:
                 raise TypeError("Value should be a list when not giving an index in an indexed header")
             else:
                 raise IndexError("Index cannot be None when not giving a list in an indexed header")
-        self.has_values = True
         self.values[option].set_value(value=value, index=index)
         return self
 
@@ -182,8 +178,6 @@ class ConfigHeader:
         if self.is_indexed and max_index is None:
             return  # if we do not know the index lets skip instead of crashing
 
-        self.has_values = True
-
         if not self.is_indexed:
             max_index = None
         else:
@@ -195,7 +189,6 @@ class ConfigHeader:
     def reset(self):
         for value_name in self.values:
             self.values[value_name].reset()
-        self.has_values = False
 
     def __str__(self):
         string = ''


### PR DESCRIPTION
The parameter has_values did not function properly, there could be values in there since the boolean was False. It also has no usages, except for the has_section which caused a bug in loading orange loadout from the gui.