### PR TITLE
Adding flatbuffer definitions to support ball predictions.

### DIFF
--- a/src/main/flatbuffers/rlbot.fbs
+++ b/src/main/flatbuffers/rlbot.fbs
@@ -350,3 +350,19 @@ table TinyPacket {
     players: [TinyPlayer];
     ball: TinyBall;
 }
+
+table PredictionSlice {
+    /// The moment in game time that this prediction corresponds to.
+    /// This corresponds to 'secondsElapsed' in the GameInfo table.
+    gameSeconds: float;
+
+    /// The predicted location and motion of the object.
+    physics: Physics;
+}
+
+table BallPrediction {
+    /// A list of places the ball will be at specific times in the future.
+    /// It is guaranteed to sorted so that time increases with each slice.
+    /// It is NOT guaranteed to have a consistent amount of time between slices.
+    slices: [PredictionSlice];
+}


### PR DESCRIPTION
This is a small subset of the changes in the `prediction` branch. The prediction branch is designed to have ball prediction be computed inside the core dll and then distributed to all bots.

I'm separating this out and trying to put it in now because people are trying to run ball prediction on their own without waiting for the centralized solution in the prediction branch. By making this available now, they can leverage it to make their temporary solutions in a way that will be compatible with our long-term centralized solution.

Also, the Java framework library already contains generated classes based on these fbs definitions; I must have got ahead of myself a month or two ago. This will bring our source code in master up to date with those binaries.