### PR TITLE
Fixes for issues #194 and #205

### DIFF
--- a/src/main/python/rlbot/gui/preset_editors.py
+++ b/src/main/python/rlbot/gui/preset_editors.py
@@ -110,10 +110,10 @@ class BasePresetEditor(QtWidgets.QMainWindow):
     def save_preset_cfg(self, time_out=0):
         preset = self.get_current_preset()
         if preset.config_path is None:
-            file_path = os.path.realpath(QtWidgets.QFileDialog.getSaveFileName(self, 'Save Config', '', 'Config Files (*.cfg)')[0])
+            file_path = QtWidgets.QFileDialog.getSaveFileName(self, 'Save Config', '', 'Config Files (*.cfg)')[0]
             if file_path is None or not file_path:
                 return
-            preset.config_path = file_path
+            preset.config_path = os.path.realpath(file_path)
             del self.presets[preset.get_name()]
             old_name = preset.name
             new_name = self.validate_name(pathlib.Path(preset.config_path).stem, preset)

--- a/src/main/python/rlbot/gui/preset_editors.py
+++ b/src/main/python/rlbot/gui/preset_editors.py
@@ -322,7 +322,7 @@ class CarCustomisationDialog(BasePresetEditor, Ui_LoadoutPresetCustomiser):
         """
 
         json_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'rocket_league_items.json')
-        with open(json_path, 'r') as f:
+        with open(json_path, 'r', encoding='utf8') as f:
             sorted_items = json.load(f, parse_int=True).items()
 
         longlabel_to_id = {}

--- a/src/main/python/rlbot/gui/presets.py
+++ b/src/main/python/rlbot/gui/presets.py
@@ -28,7 +28,7 @@ class Preset:
             return
         self.config_path = file_path
         raw_parser = configparser.RawConfigParser()
-        raw_parser.read(file_path)
+        raw_parser.read(file_path, encoding='utf8')
         for section in self.config.headers.keys():
             if not raw_parser.has_section(section):
                 raise configparser.NoSectionError(section)
@@ -48,7 +48,7 @@ class Preset:
                 message_out("Saving preset " + self.name + " in " + str(self.remaining_save_timer) + " seconds", 1000)
                 self.remaining_save_timer -= 1
             else:
-                with open(self.config_path, "w") as f:
+                with open(self.config_path, "w", encoding='utf8') as f:
                     f.write(str(self.config))
                 message_out("Saved preset " + self.name + " to " + self.config_path, 5000)
                 self.save_loadout_timer.stop()

--- a/src/main/python/rlbot/gui/qt_root.py
+++ b/src/main/python/rlbot/gui/qt_root.py
@@ -319,7 +319,7 @@ class RLBotQTGui(QMainWindow, Ui_MainWindow):
             self.popup_message("This file is not a config file!", "Invalid File Extension", QMessageBox.Warning)
             return
         raw_parser = configparser.RawConfigParser()
-        raw_parser.read(config_path)
+        raw_parser.read(config_path, encoding='utf8')
         for section in self.overall_config.headers.keys():
             if not raw_parser.has_section(section):
                 self.popup_message("Config file is missing the section {}, not loading it!".format(section), "Invalid Config File", QMessageBox.Warning)
@@ -348,7 +348,7 @@ class RLBotQTGui(QMainWindow, Ui_MainWindow):
                 self.statusbar.showMessage("Saving Overall Config in " + str(self.remaining_save_timer) + " seconds")
                 self.remaining_save_timer -= 1
             else:
-                with open(self.overall_config_path, "w") as f:
+                with open(self.overall_config_path, "w", encoding='utf8') as f:
                     f.write(str(self.fixed_indices()))
                 self.statusbar.showMessage("Saved Overall Config to " + self.overall_config_path, 5000)
                 self.overall_config_timer.stop()

--- a/src/main/python/rlbot/parsing/agent_config_parser.py
+++ b/src/main/python/rlbot/parsing/agent_config_parser.py
@@ -101,7 +101,7 @@ def get_team(config, index):
 
 def get_bot_config_bundle(bot_config_path):
     raw_bot_config = configparser.RawConfigParser()
-    raw_bot_config.read(bot_config_path)
+    raw_bot_config.read(bot_config_path, encoding='utf8')
     config_directory = os.path.dirname(os.path.realpath(bot_config_path))
     return BotConfigBundle(config_directory, raw_bot_config)
 

--- a/src/main/python/rlbot/parsing/custom_config.py
+++ b/src/main/python/rlbot/parsing/custom_config.py
@@ -70,7 +70,7 @@ class ConfigObject:
             if not os.path.isfile(config):
                 raise FileNotFoundError(config)
             self.raw_config_parser = RawConfigParser()
-            self.raw_config_parser.read(config)
+            self.raw_config_parser.read(config, encoding='utf8')
             config = self.raw_config_parser
         elif isinstance(config, RawConfigParser):
             self.raw_config_parser = config


### PR DESCRIPTION
Issue #194 was solved by explicitly telling we want to use 'utf8' encoding.
Issue #205 happened because realpath does not return an empty string when passing it an empty string, but instead uses the root directory, was solved by first obtaining the file path through the popup, then checking if it is a path, and after that using realpath.