### PR TITLE
Ability to force reload of all bots by pressing 'r'. Press 'q' to quit.

### DIFF
--- a/src/main/python/rlbot/botmanager/bot_manager.py
+++ b/src/main/python/rlbot/botmanager/bot_manager.py
@@ -133,7 +133,6 @@ class BotManager:
         if hasattr(old_agent, 'retire'):
             old_agent.retire()
 
-        self.reload_request_event.clear()
         return agent, agent_class_file
 
     def run(self):
@@ -173,8 +172,8 @@ class BotManager:
                 try:
                     new_module_modification_time = os.stat(agent_class_file).st_mtime
                     if new_module_modification_time != last_module_modification_time or self.reload_request_event.is_set():
+                        self.reload_request_event.clear()
                         last_module_modification_time = new_module_modification_time
-                        # Reloading also clears event
                         agent, agent_class_file = self.reload_agent(agent, agent_class_file)
                 except FileNotFoundError:
                     self.logger.error("Agent file {} was not found. Will try again.".format(agent_class_file))

--- a/src/main/python/rlbot/botmanager/bot_manager.py
+++ b/src/main/python/rlbot/botmanager/bot_manager.py
@@ -20,8 +20,8 @@ MAX_CARS = 10
 
 
 class BotManager:
-    def __init__(self, terminate_request_event, termination_complete_event, reload_request_event, reload_complete_event,
-                 bot_configuration, name, team, index, agent_class_wrapper, agent_metadata_queue, quick_chat_queue_holder):
+    def __init__(self, terminate_request_event, termination_complete_event, reload_request_event, bot_configuration,
+                 name, team, index, agent_class_wrapper, agent_metadata_queue, quick_chat_queue_holder):
         """
         :param terminate_request_event: an Event (multiprocessing) which will be set from the outside when the program is trying to terminate
         :param termination_complete_event: an Event (multiprocessing) which should be set from inside this class when termination has completed successfully
@@ -39,7 +39,6 @@ class BotManager:
         self.terminate_request_event = terminate_request_event
         self.termination_complete_event = termination_complete_event
         self.reload_request_event = reload_request_event
-        self.reload_complete_event = reload_complete_event
         self.bot_configuration = bot_configuration
         self.name = name
         self.team = team
@@ -135,7 +134,6 @@ class BotManager:
             old_agent.retire()
 
         self.reload_request_event.clear()
-        self.reload_complete_event.set()
         return agent, agent_class_file
 
     def run(self):

--- a/src/main/python/rlbot/botmanager/bot_manager_flatbuffer.py
+++ b/src/main/python/rlbot/botmanager/bot_manager_flatbuffer.py
@@ -3,13 +3,13 @@ from rlbot.messages.flat import GameTickPacket
 
 
 class BotManagerFlatbuffer(BotManager):
-    def __init__(self, terminate_request_event, termination_complete_event, reload_request_event, reload_complete_event,
-                 bot_configuration, name, team, index, agent_class_wrapper, agent_metadata_queue, quick_chat_queue_holder):
+    def __init__(self, terminate_request_event, termination_complete_event, reload_request_event, bot_configuration,
+                 name, team, index, agent_class_wrapper, agent_metadata_queue, quick_chat_queue_holder):
         """
         See documentation on BotManager.
         """
-        super().__init__(terminate_request_event, termination_complete_event, reload_request_event, reload_complete_event,
-                         bot_configuration, name, team, index, agent_class_wrapper, agent_metadata_queue, quick_chat_queue_holder)
+        super().__init__(terminate_request_event, termination_complete_event, reload_request_event, bot_configuration,
+                         name, team, index, agent_class_wrapper, agent_metadata_queue, quick_chat_queue_holder)
         self.game_tick_flat = None
         self.game_tick_flat_binary = None
 

--- a/src/main/python/rlbot/botmanager/bot_manager_flatbuffer.py
+++ b/src/main/python/rlbot/botmanager/bot_manager_flatbuffer.py
@@ -3,13 +3,13 @@ from rlbot.messages.flat import GameTickPacket
 
 
 class BotManagerFlatbuffer(BotManager):
-    def __init__(self, terminate_request_event, termination_complete_event, bot_configuration, name, team, index,
-                 agent_class_wrapper, agent_metadata_queue, quick_chat_queue_holder):
+    def __init__(self, terminate_request_event, termination_complete_event, reload_request_event, reload_complete_event,
+                 bot_configuration, name, team, index, agent_class_wrapper, agent_metadata_queue, quick_chat_queue_holder):
         """
         See documentation on BotManager.
         """
-        super().__init__(terminate_request_event, termination_complete_event, bot_configuration, name, team, index,
-                         agent_class_wrapper, agent_metadata_queue, quick_chat_queue_holder)
+        super().__init__(terminate_request_event, termination_complete_event, reload_request_event, reload_complete_event,
+                         bot_configuration, name, team, index, agent_class_wrapper, agent_metadata_queue, quick_chat_queue_holder)
         self.game_tick_flat = None
         self.game_tick_flat_binary = None
 

--- a/src/main/python/rlbot/botmanager/bot_manager_independent.py
+++ b/src/main/python/rlbot/botmanager/bot_manager_independent.py
@@ -2,13 +2,13 @@ from rlbot.botmanager.bot_manager import BotManager
 
 
 class BotManagerIndependent(BotManager):
-    def __init__(self, terminate_request_event, termination_complete_event, reload_request_event, reload_complete_event,
-                 bot_configuration, name, team, index, agent_class_wrapper, agent_metadata_queue, quick_chat_queue_holder):
+    def __init__(self, terminate_request_event, termination_complete_event, reload_request_event, bot_configuration,
+                 name, team, index, agent_class_wrapper, agent_metadata_queue, quick_chat_queue_holder):
         """
         See documentation on BotManager.
         """
-        super().__init__(terminate_request_event, termination_complete_event, reload_request_event, reload_complete_event,
-                         bot_configuration, name, team, index, agent_class_wrapper, agent_metadata_queue, quick_chat_queue_holder)
+        super().__init__(terminate_request_event, termination_complete_event, reload_request_event, bot_configuration,
+                         name, team, index, agent_class_wrapper, agent_metadata_queue, quick_chat_queue_holder)
 
     def run(self):
         # Get bot module

--- a/src/main/python/rlbot/botmanager/bot_manager_independent.py
+++ b/src/main/python/rlbot/botmanager/bot_manager_independent.py
@@ -2,13 +2,13 @@ from rlbot.botmanager.bot_manager import BotManager
 
 
 class BotManagerIndependent(BotManager):
-    def __init__(self, terminate_request_event, termination_complete_event, bot_configuration, name, team, index,
-                 agent_class_wrapper, agent_metadata_queue, quick_chat_queue_holder):
+    def __init__(self, terminate_request_event, termination_complete_event, reload_request_event, reload_complete_event,
+                 bot_configuration, name, team, index, agent_class_wrapper, agent_metadata_queue, quick_chat_queue_holder):
         """
         See documentation on BotManager.
         """
-        super().__init__(terminate_request_event, termination_complete_event, bot_configuration, name, team, index,
-                         agent_class_wrapper, agent_metadata_queue, quick_chat_queue_holder)
+        super().__init__(terminate_request_event, termination_complete_event, reload_request_event, reload_complete_event,
+                         bot_configuration, name, team, index, agent_class_wrapper, agent_metadata_queue, quick_chat_queue_holder)
 
     def run(self):
         # Get bot module

--- a/src/main/python/rlbot/botmanager/bot_manager_struct.py
+++ b/src/main/python/rlbot/botmanager/bot_manager_struct.py
@@ -7,13 +7,13 @@ from rlbot.utils.structures.bot_input_struct import PlayerInput
 
 
 class BotManagerStruct(BotManager):
-    def __init__(self, terminate_request_event, termination_complete_event, bot_configuration, name, team, index,
-                 agent_class_wrapper, agent_metadata_queue, quick_chat_queue_holder):
+    def __init__(self, terminate_request_event, termination_complete_event, reload_request_event, reload_complete_event,
+                 bot_configuration, name, team, index, agent_class_wrapper, agent_metadata_queue, quick_chat_queue_holder):
         """
         See documentation on BotManager.
         """
-        super().__init__(terminate_request_event, termination_complete_event, bot_configuration, name, team, index,
-                         agent_class_wrapper, agent_metadata_queue, quick_chat_queue_holder)
+        super().__init__(terminate_request_event, termination_complete_event, reload_request_event, reload_complete_event,
+                         bot_configuration, name, team, index, agent_class_wrapper, agent_metadata_queue, quick_chat_queue_holder)
         self.game_tick_proto = None
 
     def prepare_for_run(self):

--- a/src/main/python/rlbot/botmanager/bot_manager_struct.py
+++ b/src/main/python/rlbot/botmanager/bot_manager_struct.py
@@ -7,13 +7,13 @@ from rlbot.utils.structures.bot_input_struct import PlayerInput
 
 
 class BotManagerStruct(BotManager):
-    def __init__(self, terminate_request_event, termination_complete_event, reload_request_event, reload_complete_event,
-                 bot_configuration, name, team, index, agent_class_wrapper, agent_metadata_queue, quick_chat_queue_holder):
+    def __init__(self, terminate_request_event, termination_complete_event, reload_request_event, bot_configuration,
+                 name, team, index, agent_class_wrapper, agent_metadata_queue, quick_chat_queue_holder):
         """
         See documentation on BotManager.
         """
-        super().__init__(terminate_request_event, termination_complete_event, reload_request_event, reload_complete_event,
-                         bot_configuration, name, team, index, agent_class_wrapper, agent_metadata_queue, quick_chat_queue_holder)
+        super().__init__(terminate_request_event, termination_complete_event, reload_request_event, bot_configuration,
+                         name, team, index, agent_class_wrapper, agent_metadata_queue, quick_chat_queue_holder)
         self.game_tick_proto = None
 
     def prepare_for_run(self):

--- a/src/main/python/rlbot/setup_manager.py
+++ b/src/main/python/rlbot/setup_manager.py
@@ -123,12 +123,12 @@ class SetupManager:
             # Handle commands
             if msvcrt.kbhit():
                 command = msvcrt.getwch()
-                if command.lower() == 'r':  # reload
+                if command.lower() == 'r':  # r: reload
                     self.reload_all_agents()
-                elif command.lower() == 'q':  # quit
+                elif command.lower() == 'q' or command == '\u001b':  # q or ESC: quit
                     self.shut_down()
                     break
-                # Only print instructions if a alphabet character was pressed and no command was found
+                # Print instructions again if a alphabet character was pressed but no command was found
                 elif command.isalpha():
                     self.logger.info(instructions)
 


### PR DESCRIPTION
Works by passing an event to BotManager which will make it reload when set.
BotManager still reloads on file modification.
Made sure it worked, when a human is playing.
You have to press 'q' to quit now.
More commands should be easy to add in the future.