### PR TITLE
Add Rust support

### DIFF
--- a/src/main/python/rlbot/agents/base_subprocess_agent.py
+++ b/src/main/python/rlbot/agents/base_subprocess_agent.py
@@ -1,0 +1,30 @@
+from multiprocessing import Event
+from signal import CTRL_C_EVENT
+from subprocess import Popen
+
+from rlbot.agents.base_agent import BOT_CONFIG_AGENT_HEADER
+from rlbot.agents.base_independent_agent import BaseIndependentAgent
+from rlbot.parsing.custom_config import ConfigHeader, ConfigObject
+
+
+class BaseSubprocessAgent(BaseIndependentAgent):
+    """An Agent which simply delegates to an external process."""
+
+    path: str
+
+    @staticmethod
+    def create_agent_configurations(config: ConfigObject):
+        params = config.get_header(BOT_CONFIG_AGENT_HEADER)
+        params.add_value('path', str, description='The path to the exe for the bot')
+
+    def load_config(self, config_header: ConfigHeader) -> None:
+        self.path = config_header.get('path')
+
+    def run_independently(self, terminate_request_event: Event) -> None:
+        # This argument sequence is consumed by Rust's `rlbot::run`.
+        process = Popen([self.path, '--player-index', str(self.index)])
+
+        # Block until we are asked to terminate, and then do so.
+        terminate_request_event.wait()
+        process.send_signal(CTRL_C_EVENT)
+        process.wait()


### PR DESCRIPTION
This is very simple, it just spawns an external process that loads its own copy of the interface DLL. One process per agent.

The Rust half of this PR is [here](https://gitlab.com/whatisaphone/rlbot-rust/merge_requests/1). I tested the two PRs together and successfully saw some nice dual-atba action.

## Highlights from the other PR:

The bot.cfg includes this:

```ini
[Bot Parameters]
path = target/debug/examples/bot.exe
```

The required python file looks like this:

```py
from rlbot.agents.base_subprocess_agent import BaseSubprocessAgent


class MyAgent(BaseSubprocessAgent):
    pass
```

That's simple enough that I wish there was a way to make it go away, but maybe that's not possible.

I'll leave it open for a few days in case anyone (particularly @ehsanul) has comments.