### PR TITLE
Improved startup and shutdown behavior

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 }
 
 project.setGroup('org.rlbot.commons')
-project.setVersion('1.0.0')
+project.setVersion('1.1.0')
 
 def pythonRoot = './src/main/python/'
 

--- a/src/main/java/rlbot/manager/BotManager.java
+++ b/src/main/java/rlbot/manager/BotManager.java
@@ -42,8 +42,9 @@ public class BotManager {
     private void doRunBot(final Bot bot, final int index, final AtomicBoolean runFlag) {
 
         final BotLoopRenderer renderer = BotLoopRenderer.forBotLoop(bot);
-        while (keepRunning && runFlag.get()) {
-            try {
+        try {
+            while (keepRunning && runFlag.get()) {
+
                 synchronized (dinnerBell) {
                     // Wait for the main thread to indicate that we have new game tick data.
                     dinnerBell.wait(1000);
@@ -54,11 +55,14 @@ public class BotManager {
                     RLBotDll.setPlayerInputFlatbuffer(controllerState, index);
                     renderer.finishAndSendIfDifferent();
                 }
-            } catch (InterruptedException e) {
-                e.printStackTrace();
             }
+        } catch (Exception e) {
+            System.out.println("Bot died because an exception occurred in the run loop!");
+            e.printStackTrace();
+        } finally {
+            retireBot(index); // Unregister this bot internally.
+            bot.retire(); // Tell the bot to clean up its resources.
         }
-        bot.retire();
     }
 
     public void ensureStarted() {

--- a/src/main/java/rlbot/pyinterop/DefaultPythonInterface.java
+++ b/src/main/java/rlbot/pyinterop/DefaultPythonInterface.java
@@ -27,7 +27,14 @@ public abstract class DefaultPythonInterface implements PythonInterface {
     }
 
     public void shutdown() {
+        System.out.println("Shutting down...");
         botManager.shutDown();
+        try {
+            Thread.sleep(1500); // Wait for the bots to finish up
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        System.exit(0);
     }
 
     public void ensureBotRegistered(final int index, final String botType, final int team) {

--- a/src/main/python/rlbot/agents/base_java_agent.py
+++ b/src/main/python/rlbot/agents/base_java_agent.py
@@ -1,14 +1,12 @@
-import msvcrt
-import os
 import time
 
 import psutil
 from py4j.java_gateway import GatewayParameters
 from py4j.java_gateway import JavaGateway
-from rlbot.utils.structures import game_interface
 
 from rlbot.agents.base_independent_agent import BaseIndependentAgent
 from rlbot.utils.logging_utils import get_logger
+from rlbot.utils.structures import game_interface
 
 
 class BaseJavaAgent(BaseIndependentAgent):
@@ -64,7 +62,9 @@ class BaseJavaAgent(BaseIndependentAgent):
 
     def retire(self):
         try:
-            self.javaInterface.retireBot(self.index)
+            # Shut down the whole java process, because currently java is clumsy with the interface dll
+            # and cannot really survive a restart of the python framework.
+            self.javaInterface.shutdown()
         except Exception as e:
             self.logger.warn(str(e))
         self.is_retired = True

--- a/src/main/python/rlbot/gui/qt_root.py
+++ b/src/main/python/rlbot/gui/qt_root.py
@@ -93,6 +93,16 @@ class RLBotQTGui(QMainWindow, Ui_MainWindow):
         return config
 
     def run_button_pressed(self):
+        if self.setup_manager is not None:
+            if self.setup_manager.quit_event.is_set():
+                # Do nothing if the quit event is set. This means that we're already trying to shut down.
+                # Attempting to run again when we're in this state can result in duplicate processes.
+                return
+            self.setup_manager.shut_down(time_limit=5, kill_all_pids=False)
+            # Leave any external processes alive, e.g. Java or C#, since it can
+            # be useful to keep them around. The user can kill them with the
+            # Kill Bots button instead.
+
         self.match_process = threading.Thread(target=self.start_match)
         self.match_process.start()
 
@@ -101,12 +111,6 @@ class RLBotQTGui(QMainWindow, Ui_MainWindow):
         Starts a match with the current configuration
         :return:
         """
-
-        if self.setup_manager is not None:
-            self.setup_manager.shut_down(time_limit=5, kill_all_pids=False)
-            # Leave any external processes alive, e.g. Java or C#, since it can
-            # be useful to keep them around. The user can kill them with the
-            # Kill Bots button instead.
 
         agent_configs_dict = {}
         loadout_configs_dict = {}

--- a/src/main/python/rlbot/runner.py
+++ b/src/main/python/rlbot/runner.py
@@ -9,7 +9,6 @@ def main():
     manager.load_config()
     manager.launch_bot_processes()
     manager.run()  # Runs forever until interrupted
-    manager.shut_down()
 
 
 if __name__ == '__main__':

--- a/src/main/python/rlbot/version.py
+++ b/src/main/python/rlbot/version.py
@@ -3,9 +3,16 @@
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module module
 # https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
-__version__ = '1.1.2'
+__version__ = '1.1.3'
 
 release_notes = {
+    '1.1.3': """
+    - Faster way to access ball prediction data in python. - Skyborg
+    - Java bots will now shut down when the python framework quits. This has been necessary recently
+    to avoid buggy situations.
+    - Shutting down the python framework will no longer attempt to kill bots twice in a row.
+    - Clicking on the "Run" button twice in a row in the GUI will no longer spawn duplicate processes.
+    """,
     '1.1.2': """
     Faster way to access ball prediction data in python. - Skyborg
     """,


### PR DESCRIPTION
- Java bots will now shut down when the python framework quits. This avoid some bugs where java's interface dll has stale shared memory mappings.
- Clicking the run button twice no longer causes a duplicate process disaster
- Shutting down the python framework only attempts to kill bots once, not twice.
- Improved exception handling for java bots. If there's an unhandled exception, the bot will now retire and get restarted from python. Previously it would just stop.