### PR TITLE
Using 32 bit dll when running in 32 bit JVM. Targeting 1.8.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,9 @@ repositories {
     jcenter()
 }
 
+sourceCompatibility = '1.8'
+targetCompatibility = '1.8'
+
 def javaDllDir = 'build/dll'
 
 dependencies {


### PR DESCRIPTION
32 bit JVM needs the 32 bit dll. Currently it does not get it, and just fails. If people install the default JRE they end up with a 32 bit JVM, so this is a big problem for people just hoping to try out bots.

They also get Java 8 by default. If we accidentally build the framework jar targeting java 10, they will be unable to run it.

This fixes all that.