### PR TITLE
Failing fast with specific errors when cfg files are messed up.

### DIFF
--- a/src/main/python/rlbot/agents/base_agent.py
+++ b/src/main/python/rlbot/agents/base_agent.py
@@ -243,9 +243,9 @@ class BaseAgent:
         """
         config = ConfigObject()
         location_config = config.add_header_name(BOT_CONFIG_MODULE_HEADER)
-        location_config.add_value(LOOKS_CONFIG_KEY, str, default='./atba_looks.cfg',
+        location_config.add_value(LOOKS_CONFIG_KEY, str,
                                   description='Path to loadout config from runner')
-        location_config.add_value(PYTHON_FILE_KEY, str, default='./atba.py',
+        location_config.add_value(PYTHON_FILE_KEY, str,
                                   description="Bot's python file.\nOnly need this if RLBot controlled")
         location_config.add_value(BOT_NAME_KEY, str, default='nameless',
                                   description='The name that will be displayed in game')

--- a/src/main/python/rlbot/gui/preset_editors.py
+++ b/src/main/python/rlbot/gui/preset_editors.py
@@ -469,9 +469,12 @@ class AgentCustomisationDialog(BasePresetEditor, Ui_AgentPresetCustomiser):
         if not file_path or not os.path.exists(file_path):
             return
         preset = self.get_current_preset()
-        if not preset.load_agent_class(file_path):
-            self.popup_message("This file does not extend BaseAgent, using BaseAgent", "Invalid Python File",
-                               QtWidgets.QMessageBox.Information)
+        try:
+            preset.load_agent_class(file_path)
+        except FileNotFoundError as e:
+            self.popup_message(str(e), "Invalid Python File", QtWidgets.QMessageBox.Information)
+            return
+
         if preset.config_path is None or not os.path.isfile(preset.config_path):
             start = get_python_root()
         else:

--- a/src/main/python/rlbot/gui/preset_editors.py
+++ b/src/main/python/rlbot/gui/preset_editors.py
@@ -471,7 +471,7 @@ class AgentCustomisationDialog(BasePresetEditor, Ui_AgentPresetCustomiser):
         preset = self.get_current_preset()
         try:
             preset.load_agent_class(file_path)
-        except FileNotFoundError as e:
+        except (FileNotFoundError, ModuleNotFoundError) as e:
             self.popup_message(str(e), "Invalid Python File", QtWidgets.QMessageBox.Information)
             return
 

--- a/src/main/python/rlbot/gui/presets.py
+++ b/src/main/python/rlbot/gui/presets.py
@@ -91,8 +91,8 @@ class AgentPreset(Preset):
 
         try:
             self.agent_class = import_agent(python_file_path).get_loaded_class()
-        except (ValueError, ModuleNotFoundError):
-            self.agent_class = BaseAgent
+        except (ValueError, ModuleNotFoundError, FileNotFoundError) as e:
+            raise ValueError("Problem when processing {}: {}".format(file_path, str(e)))
 
         super().__init__(self.agent_class.base_create_agent_configurations(), file_path, name)
         # Make sure the path to the python file actually gets set to that path, even if there was no config at file_path
@@ -104,11 +104,7 @@ class AgentPreset(Preset):
 
     def load_agent_class(self, python_file_path):
         result = True
-        try:
-            self.agent_class = import_agent(python_file_path).get_loaded_class()
-        except (ValueError, ModuleNotFoundError):
-            self.agent_class = BaseAgent
-            result = False
+        self.agent_class = import_agent(python_file_path).get_loaded_class()
         old_config = self.config.copy()
         self.config = self.agent_class.base_create_agent_configurations()
         self.config.parse_file(old_config)

--- a/src/main/python/rlbot/gui/qt_root.py
+++ b/src/main/python/rlbot/gui/qt_root.py
@@ -551,8 +551,11 @@ class RLBotQTGui(QMainWindow, Ui_MainWindow):
             self.overall_config = config_file
         self.agents.clear()
         num_participants = get_num_players(self.overall_config)
-        for i in range(num_participants):
-            self.load_agent(i)
+        try:
+            for i in range(num_participants):
+                self.load_agent(i)
+        except BaseException as e:
+            raise ValueError(str(e) + " Please check your config files!".format(self.overall_config_path))
 
     def load_agent(self, overall_index: int=None):
         """
@@ -646,13 +649,14 @@ class RLBotQTGui(QMainWindow, Ui_MainWindow):
     def add_agent_preset(self, file_path):
         """
         Loads a preset using file_path with all values from that path loaded
-        :param file_path: the path to load the preset from, if invalid a default preset is returned
+        :param file_path: the path to load the preset from. We'll throw an exception if it's invalid.
         :return preset: the agent preset created
         """
         if os.path.isfile(file_path):
             name = pathlib.Path(file_path).stem
         else:
-            name = "new preset"
+            raise FileNotFoundError("File path {} is not found!".format(file_path))
+
         if name in self.agent_presets:
             return self.agent_presets[name]
         preset = AgentPreset(name, file_path)

--- a/src/main/python/rlbot/parsing/agent_config_parser.py
+++ b/src/main/python/rlbot/parsing/agent_config_parser.py
@@ -28,7 +28,7 @@ class BotConfigBundle:
     def get_absolute_path(self, header, key):
         path = self.base_agent_config.get(header, key)
         if path is None:
-            raise ValueError("Could not find {}: {} in the provided configuration!".format(header, key))
+            raise configparser.NoSectionError("Could not find {}: {} in the provided configuration!".format(header, key))
         if os.path.isabs(path):
             return path
         if self.config_directory is None:

--- a/src/main/python/rlbot/parsing/agent_config_parser.py
+++ b/src/main/python/rlbot/parsing/agent_config_parser.py
@@ -27,6 +27,8 @@ class BotConfigBundle:
 
     def get_absolute_path(self, header, key):
         path = self.base_agent_config.get(header, key)
+        if path is None:
+            raise ValueError("Could not find {}: {} in the provided configuration!".format(header, key))
         if os.path.isabs(path):
             return path
         if self.config_directory is None:
@@ -107,6 +109,8 @@ def get_team(config, index):
 def get_bot_config_bundle(bot_config_path):
     raw_bot_config = configparser.RawConfigParser()
     raw_bot_config.read(bot_config_path, encoding='utf8')
+    if not os.path.isfile(bot_config_path):
+        raise FileNotFoundError("Could not find bot config file {}!".format(bot_config_path))
     config_directory = os.path.dirname(os.path.realpath(bot_config_path))
     return BotConfigBundle(config_directory, raw_bot_config)
 

--- a/src/main/python/rlbot/utils/class_importer.py
+++ b/src/main/python/rlbot/utils/class_importer.py
@@ -88,7 +88,7 @@ def extract_class(containing_module, base_class):
                      if issubclass(agent[1], base_class) and agent[1].__module__ == containing_module.__name__]
 
     if len(valid_classes) == 0:
-        raise ValueError('Could not locate a suitable bot class in module {}'.format(containing_module.__file__))
+        raise ModuleNotFoundError('Could not locate a suitable bot class in module {}'.format(containing_module.__file__))
 
     return valid_classes[0]
 

--- a/src/main/python/rlbot/utils/class_importer.py
+++ b/src/main/python/rlbot/utils/class_importer.py
@@ -60,6 +60,9 @@ def load_external_class(python_file, base_class):
     if os.path.abspath(python_file) == os.path.abspath(inspect.getfile(BaseAgent)):
         return BaseAgent, BaseAgent.__module__
 
+    if not os.path.isfile(python_file):
+        raise FileNotFoundError("Could not find file {}!".format(python_file))
+
     dir_name = os.path.dirname(python_file)
     module_name = os.path.splitext(os.path.basename(python_file))[0]
     keys_before = set(sys.modules.keys())
@@ -85,7 +88,7 @@ def extract_class(containing_module, base_class):
                      if issubclass(agent[1], base_class) and agent[1].__module__ == containing_module.__name__]
 
     if len(valid_classes) == 0:
-        raise ValueError('Could not locate a suitable bot class')
+        raise ValueError('Could not locate a suitable bot class in module {}'.format(containing_module.__file__))
 
     return valid_classes[0]
 

--- a/src/main/python/rlbot/version.py
+++ b/src/main/python/rlbot/version.py
@@ -3,10 +3,10 @@
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module module
 # https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
-__version__ = '1.2.4'
+__version__ = '1.2.5'
 
 release_notes = {
-    '1.2.4': """
+    '1.2.5': """
     ***************************************************
     *  Fix for dodge cancels / half flips! - ccman32  *
     ***************************************************
@@ -19,6 +19,7 @@ release_notes = {
     - Fixed a bug where party_member_bot could get influenced by real controller input.
     - Creating new presets in the GUI works better now.
     - Got rid of the libpng warning seen when using the GUI.
+    - Giving specific error messages when cfg files are messed up.
     """,
     '1.2.2': """
     - Rearranged the GUI a bit, and made it load and track appearance configs more effectively.


### PR DESCRIPTION
There are lots of different cfg problems that manifest as a "Could not locate a suitable bot class" error, when really the user just has an invalid file path. This should give accurate error messages.

Also better in general to fail fast rather than confuse people with bot behavior or loadout configs that they don't expect, e.g. atba looks and not moving.