### PR TITLE
Fixing output piping for auto-run executables.

### DIFF
--- a/src/main/python/rlbot/botmanager/helper_process_manager.py
+++ b/src/main/python/rlbot/botmanager/helper_process_manager.py
@@ -39,8 +39,7 @@ class HelperProcessManager:
                     self.helper_process_map[helper_req.key] = metadata_queue
 
                 if helper_req.executable is not None:
-                    process = subprocess.Popen([helper_req.executable],
-                                               stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                    process = subprocess.Popen([helper_req.executable])
 
                     agent_metadata.pids.add(process.pid)
 

--- a/src/main/python/rlbot/version.py
+++ b/src/main/python/rlbot/version.py
@@ -3,12 +3,15 @@
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module module
 # https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
-__version__ = '1.4.0'
+__version__ = '1.4.1'
 
 release_notes = {
-    '1.4.0': """
+    '1.4.1': """
     Adding support for auto-running java bots during tournaments. To take advantage of this
     in your bot, see https://github.com/RLBot/RLBotJavaExample/wiki/Auto-Launching-Java
+    
+    Plus bug fixes:
+    - Fixed a bug where auto-run executables would crash when trying to write to stderr.
     """,
     '1.3.0': """
     Accurate ball prediction for Hoops and Dropshot modes!


### PR DESCRIPTION
I noticed that my Java bot would stop working sometimes, and I believe it occurred when it tried to print an exception to stderr. Works fine after this change.