### PR TITLE
Fix GUI preset load and relative path problems

### DIFF
--- a/src/main/python/rlbot/agents/base_subprocess_agent.py
+++ b/src/main/python/rlbot/agents/base_subprocess_agent.py
@@ -18,11 +18,11 @@ class BaseSubprocessAgent(BaseIndependentAgent):
         params.add_value('path', str, description='The path to the exe for the bot')
 
     def load_config(self, config_header: ConfigHeader) -> None:
-        self.path = config_header.get('path')
+        self.path = config_header.getpath('path')
 
     def run_independently(self, terminate_request_event: Event) -> None:
         # This argument sequence is consumed by Rust's `rlbot::run`.
-        process = Popen([self.path, '--player-index', str(self.index)])
+        process = Popen(['run', self.path, '--player-index', str(self.index)])
 
         # Block until we are asked to terminate, and then do so.
         terminate_request_event.wait()

--- a/src/main/python/rlbot/agents/base_subprocess_agent.py
+++ b/src/main/python/rlbot/agents/base_subprocess_agent.py
@@ -22,7 +22,7 @@ class BaseSubprocessAgent(BaseIndependentAgent):
 
     def run_independently(self, terminate_request_event: Event) -> None:
         # This argument sequence is consumed by Rust's `rlbot::run`.
-        process = Popen(['run', self.path, '--player-index', str(self.index)])
+        process = Popen([self.path, '--player-index', str(self.index)])
 
         # Block until we are asked to terminate, and then do so.
         terminate_request_event.wait()

--- a/src/main/python/rlbot/gui/gui_agent.py
+++ b/src/main/python/rlbot/gui/gui_agent.py
@@ -58,7 +58,7 @@ class GUIAgent:
         return self.agent_preset
 
     def get_agent_config_path(self):
-        return os.path.realpath(self.overall_config.get(PARTICIPANT_CONFIGURATION_HEADER,
+        return os.path.realpath(self.overall_config.getpath(PARTICIPANT_CONFIGURATION_HEADER,
                                                         PARTICIPANT_CONFIG_KEY, self.overall_index))
 
     def set_agent_config_path(self, config_path: str):

--- a/src/main/python/rlbot/gui/qt_root.py
+++ b/src/main/python/rlbot/gui/qt_root.py
@@ -103,7 +103,7 @@ class RLBotQTGui(QMainWindow, Ui_MainWindow):
             # Leave any external processes alive, e.g. Java or C#, since it can
             # be useful to keep them around. The user can kill them with the
             # Kill Bots button instead.
-
+            
         self.match_process = threading.Thread(target=self.start_match)
         self.match_process.start()
 
@@ -382,7 +382,7 @@ class RLBotQTGui(QMainWindow, Ui_MainWindow):
                 self.popup_message("Config file is missing the section {}, not loading it!".format(section), "Invalid Config File", QMessageBox.Warning)
                 return
         self.overall_config_path = config_path
-        self.overall_config.parse_file(raw_parser, 10)
+        self.overall_config.parse_file(raw_parser, 10, config_directory=os.path.dirname(self.overall_config_path))
         self.load_agents()
         self.update_teams_listwidgets()
         self.cfg_file_path_lineedit.setText(self.overall_config_path)

--- a/src/main/python/rlbot/gui/qt_root.py
+++ b/src/main/python/rlbot/gui/qt_root.py
@@ -668,7 +668,14 @@ class RLBotQTGui(QMainWindow, Ui_MainWindow):
             raise FileNotFoundError("File path {} is not found!".format(file_path))
 
         if name in self.agent_presets:
-            return self.agent_presets[name]
+            if self.agent_presets[name].config_path == file_path:
+                return self.agent_presets[name].get
+            else:
+                i = 1
+                for preset_name in self.agent_presets.keys():
+                    if name in preset_name:
+                        i += 1
+                name = name + ' ({})'.format(i)
         preset = AgentPreset(name, file_path)
         self.agent_presets[preset.get_name()] = preset
         return preset

--- a/src/main/python/rlbot/gui/qt_root.py
+++ b/src/main/python/rlbot/gui/qt_root.py
@@ -103,7 +103,7 @@ class RLBotQTGui(QMainWindow, Ui_MainWindow):
             # Leave any external processes alive, e.g. Java or C#, since it can
             # be useful to keep them around. The user can kill them with the
             # Kill Bots button instead.
-            
+
         self.match_process = threading.Thread(target=self.start_match)
         self.match_process.start()
 

--- a/src/main/python/rlbot/gui/qt_root.py
+++ b/src/main/python/rlbot/gui/qt_root.py
@@ -669,10 +669,10 @@ class RLBotQTGui(QMainWindow, Ui_MainWindow):
 
         if name in self.agent_presets:
             if self.agent_presets[name].config_path == file_path:
-                return self.agent_presets[name].get
+                return self.agent_presets[name]
             else:
                 i = 1
-                for preset_name in self.agent_presets.keys():
+                for preset_name in self.agent_presets:
                     if name in preset_name:
                         i += 1
                 name = name + ' ({})'.format(i)

--- a/src/main/python/rlbot/version.py
+++ b/src/main/python/rlbot/version.py
@@ -6,6 +6,10 @@
 __version__ = '1.6.0'
 
 release_notes = {
+    '1.6.1': """
+    Fixed GUI crash when loading certain RLBot config files with relative paths for agents.
+    Fixed agent preset loading to allow multiple agents to saved/loaded correctly if they have the same name. - ima9rd
+    """,
     '1.6.0':"""
     Add support for auto starting .NET executables.
     """,

--- a/src/main/python/rlbot/version.py
+++ b/src/main/python/rlbot/version.py
@@ -3,7 +3,7 @@
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module module
 # https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
-__version__ = '1.6.0'
+__version__ = '1.6.1'
 
 release_notes = {
     '1.6.1': """


### PR DESCRIPTION
This fixes GUI loading to not discard preset configuration files that share the same name but are located in different directories. The GUI would correctly save the rlbot.cfg file when multiple agents were added with the same name, but the loading code would overwrite all presets loaded after the initial due to matching on preset name alone.