### PR TITLE
Don't scare people by logging to info about locked files.

### DIFF
--- a/src/main/python/rlbot/utils/file_util.py
+++ b/src/main/python/rlbot/utils/file_util.py
@@ -27,6 +27,6 @@ def contains_locked_file(directory: str):
                 with open(file_path, 'a'):
                     pass
             except IOError:
-                logger.info("Locked file: {}".format(file_path))
+                logger.debug("Locked file: {}".format(file_path))
                 return True
     return False


### PR DESCRIPTION
People have assumed that this is the root cause of their error about 9000 times. Using logger.debug makes it not appear in the console anymore (currently we only log at info level).