### PR TITLE
Make logging more configurable.

### DIFF
--- a/src/main/python/rlbot/agents/base_agent.py
+++ b/src/main/python/rlbot/agents/base_agent.py
@@ -60,7 +60,7 @@ class BaseAgent:
         self.name = name
         self.team = team
         self.index = index
-        self.logger = get_logger('nameless_bot')
+        self.logger = get_logger(f'bot{index}')
 
     def get_output(self, game_tick_packet: GameTickPacket) -> SimpleControllerState:
         """
@@ -181,7 +181,6 @@ class BaseAgent:
         none of the boost locations will be filled in.
         :return: A v3 version of the game tick packet"""
         return convert_to_legacy_v3(game_tick_packet, field_info_packet)
-
 
     ############
     #  Methods that should not be called or changed by subclasses

--- a/src/main/python/rlbot/botmanager/bot_manager.py
+++ b/src/main/python/rlbot/botmanager/bot_manager.py
@@ -79,7 +79,6 @@ class BotManager:
         """
         agent_class = self.agent_class_wrapper.get_loaded_class()
         agent = agent_class(self.name, self.team, self.index)
-        agent.logger = self.logger
         agent.load_config(self.bot_configuration.get_header("Bot Parameters"))
 
         self.update_metadata_queue(agent)

--- a/src/main/python/rlbot/utils/logging_utils.py
+++ b/src/main/python/rlbot/utils/logging_utils.py
@@ -3,21 +3,21 @@ import logging
 
 
 DEFAULT_LOGGER = 'rlbot'
-logger_initialized = False
 logging_level = logging.INFO
 FORMAT = "%(levelname)s:%(name)5s[%(filename)20s:%(lineno)s - %(funcName)20s() ] %(message)s"
 
+logging.getLogger().setLevel(logging.NOTSET)
+
 
 def get_logger(logger_name, log_creation=True):
-    global logger_initialized
-    if not logger_initialized:
-        logging.basicConfig(format=FORMAT, level=logging_level)
-        logging.getLogger().setLevel(logging_level)
-        logger_initialized = True
     logger = logging.getLogger(logger_name)
+    if not logger.handlers:
+        ch = logging.StreamHandler()
+        ch.setFormatter(logging.Formatter(FORMAT))
+        ch.setLevel(logging_level)
+        logger.addHandler(ch)
     if logger_name == DEFAULT_LOGGER:
         return logger
-    logger.setLevel(logging_level)
     if log_creation:
         curframe = inspect.currentframe()
         calframe = inspect.getouterframes(curframe, 2)


### PR DESCRIPTION
At the moment we can't add a handler with a level lower than the default logging_level, for example if i want to only show info logs in console but write debug level logs to a file.

We should have the level of the logger itself to be as low as possible and only set a default for the console for example.

This allows:
 - adding a handler with any level.
 - configuring the default handler (self.logger.handlers[0]) without changing the root logger and affecting all loggers.