### PR TITLE
Sorting the customisation items in the gui

### DIFF
--- a/src/main/python/rlbot/gui/preset_editors.py
+++ b/src/main/python/rlbot/gui/preset_editors.py
@@ -356,7 +356,9 @@ class CarCustomisationDialog(BasePresetEditor, Ui_LoadoutPresetCustomiser):
             if isinstance(widget, QtWidgets.QComboBox):
                 config_headers = self.config_widgets_to_headers[widget]
                 config_category = self.config_headers_to_categories[config_headers[1]]
-                widget.addItems(list(self.longlabel_to_id[config_category].keys()) + ['Unknown'])
+                sorted_list = list(self.longlabel_to_id[config_category].keys())
+                sorted_list.sort()
+                widget.addItems(sorted_list + ['Unknown'])
 
     @staticmethod
     def get_item_dicts():


### PR DESCRIPTION
This commit only changes the order in which the items get added to the combo boxes. The order in the box being changed doesn't need any other adjustments since it checks for the text and not for the index when selecting an item.