### PR TITLE
Fix double logs.

### DIFF
--- a/src/main/python/rlbot/utils/logging_utils.py
+++ b/src/main/python/rlbot/utils/logging_utils.py
@@ -16,6 +16,7 @@ def get_logger(logger_name, log_creation=True):
         ch.setFormatter(logging.Formatter(FORMAT))
         ch.setLevel(logging_level)
         logger.addHandler(ch)
+    logging.getLogger().handlers = []
     if logger_name == DEFAULT_LOGGER:
         return logger
     if log_creation:


### PR DESCRIPTION
pipmain() (used in run.py on the example bots) seems to add a handler to the root logger which resutls in a doubling of logs :

```
INFO:rlbot[   game_interface.py:196 -           inject_dll() ] Injecting DLL
Injecting DLL
```

This is a fix to that.