### PR TITLE
Interface init fix dotnet

### DIFF
--- a/src/main/cs/RLBotDotNet/RLBotDotNet/Manager/BotManager.cs
+++ b/src/main/cs/RLBotDotNet/RLBotDotNet/Manager/BotManager.cs
@@ -65,6 +65,15 @@ namespace RLBotDotNet
         {
             var renderer = GetRendererForBot(bot);
             bot.SetRenderer(renderer);
+
+            Console.WriteLine("Waiting for the RLBot Interface to initialize...");
+
+            while (!RLBotInterface.IsInitialized())
+                Thread.Sleep(100);
+
+            Console.WriteLine("The RLBot Interface has been successfully initialized!");
+            Console.WriteLine("Running the bot loop...");
+
             while (true)
             {
                 try

--- a/src/main/cs/RLBotDotNet/RLBotDotNet/Properties/AssemblyInfo.cs
+++ b/src/main/cs/RLBotDotNet/RLBotDotNet/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.0")]
-[assembly: AssemblyFileVersion("1.2.0")]
+[assembly: AssemblyVersion("1.2.2")]
+[assembly: AssemblyFileVersion("1.2.2")]

--- a/src/main/cs/RLBotDotNet/RLBotDotNet/RLBotDotNet.nuspec
+++ b/src/main/cs/RLBotDotNet/RLBotDotNet/RLBotDotNet.nuspec
@@ -4,7 +4,7 @@
     <id>RLBot.Framework</id>
     <version>$version$</version>
     <title>RLBot Framework</title>
-    <authors>Tangil Jahangir, Tyler Arehart, alion02, Whok, kipje13</authors>
+    <authors>Tangil Jahangir, Tyler Arehart, alion02, Whok, kipje13, ccman32</authors>
     <owners>rlbotofficial</owners>
     <licenseUrl>https://opensource.org/licenses/mit-license.php</licenseUrl>
     <projectUrl>https://github.com/RLBot/RLBot</projectUrl>
@@ -12,7 +12,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Framework for writing Rocket League bots in .NET languages.</description>
     <releaseNotes>
-      Adds support for reading raw physics data which contains non interpolated positions, rotations... etc.
+      Added a check to avoid calling RLBot Interface functions before the interface has been initialized
     </releaseNotes>
     <copyright>Copyright 2018</copyright>
     <tags>rocket-league</tags>


### PR DESCRIPTION
This adds a check to wait until the interface is initialized. This prevents RlBotDotNet from calling interface functions before the interface finished initializing.