### PR TITLE
Support for passing an options dict to BotHelperProcesses.

### DIFF
--- a/src/main/python/rlbot/botmanager/bot_helper_process.py
+++ b/src/main/python/rlbot/botmanager/bot_helper_process.py
@@ -8,7 +8,7 @@ class BotHelperProcess:
     with that other language.
     """
 
-    def __init__(self, metadata_queue: Queue, quit_event: Event):
+    def __init__(self, metadata_queue: Queue, quit_event: Event, options: dict):
         """
         :param metadata_queue: A multiprocessing queue that receives AgentMetadata objects when
         relevant agents are initialized.
@@ -16,6 +16,7 @@ class BotHelperProcess:
         """
         self.metadata_queue = metadata_queue
         self.quit_event = quit_event
+        self.options = options
 
     def start(self):
         raise NotImplementedError

--- a/src/main/python/rlbot/botmanager/helper_process_manager.py
+++ b/src/main/python/rlbot/botmanager/helper_process_manager.py
@@ -32,7 +32,8 @@ class HelperProcessManager:
                 metadata_queue = mp.Queue()
                 if helper_req.python_file_path is not None:
                     process = mp.Process(target=run_helper_process,
-                                         args=(helper_req.python_file_path, metadata_queue, self.quit_event, helper_req.options))
+                                         args=(helper_req.python_file_path, metadata_queue, self.quit_event,
+                                               helper_req.options))
                     process.start()
                     agent_metadata.pids.add(process.pid)
 

--- a/src/main/python/rlbot/botmanager/helper_process_request.py
+++ b/src/main/python/rlbot/botmanager/helper_process_request.py
@@ -3,13 +3,15 @@ class HelperProcessRequest:
     This class allows agents to express their need for a helper process that may be shared with other agents.
     """
 
-    def __init__(self, python_file_path: str, key: str, executable: str = None):
+    def __init__(self, python_file_path: str, key: str, executable: str = None, options: dict = None):
         """
         :param python_file_path: The file that should be loaded and inspected for a subclass of BotHelperProcess.
         :param key: A key used to control the mapping of helper processes to bots. For example, you could set
-        :param executable: A path to an executable that should be run as a separate process
         something like 'myBotType-team1' in order to get one shared helper process per team.
+        :param executable: A path to an executable that should be run as a separate process
+        :param options: A dict with arbitrary options that will be passed through to the helper process.
         """
         self.python_file_path = python_file_path
         self.key = key
         self.executable = executable
+        self.options = options

--- a/src/main/python/rlbot/version.py
+++ b/src/main/python/rlbot/version.py
@@ -4,9 +4,13 @@
 # 3) we can import it into your module module
 # https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
 
-__version__ = '1.11.1'
+__version__ = '1.12.0'
 
 release_notes = {
+
+    '1.12.0': """
+    - Support for passing an options dict to BotHelperProcesses. - tarehart
+    """,
 
     '1.11.1': """
     - Added a new field called 'teams' to packet, which contain goals scored. - Marvin


### PR DESCRIPTION
This is preparation for running scratch bots headless during tournaments. We need to pass though sb3 file paths, etc.