### PR TITLE
Adding the new Details config section to base agent configurations.

### DIFF
--- a/src/main/python/rlbot/agents/base_agent.py
+++ b/src/main/python/rlbot/agents/base_agent.py
@@ -12,6 +12,7 @@ from rlbot.utils.structures.rigid_body_struct import RigidBodyTick
 
 BOT_CONFIG_MODULE_HEADER = 'Locations'
 BOT_CONFIG_AGENT_HEADER = 'Bot Parameters'
+BOT_CONFIG_DETAILS_HEADER = 'Details'
 PYTHON_FILE_KEY = 'python_file'
 LOOKS_CONFIG_KEY = 'looks_config'
 BOT_NAME_KEY = "name"
@@ -256,6 +257,13 @@ class BaseAgent:
                                   description="Bot's python file.\nOnly need this if RLBot controlled")
         location_config.add_value(BOT_NAME_KEY, str, default='nameless',
                                   description='The name that will be displayed in game')
+
+        details_config = config.add_header_name(BOT_CONFIG_DETAILS_HEADER)
+        details_config.add_value('developer', str, description="Name of the bot's creator/developer")
+        details_config.add_value('description', str, description="Short description of the bot")
+        details_config.add_value('fun_fact', str, description="Fun fact about the bot")
+        details_config.add_value('github', str, description="Link to github repository")
+        details_config.add_value('language', str, description="Programming language")
 
         cls.create_agent_configurations(config)
 

--- a/src/main/python/rlbot/parsing/rlbot_config_parser.py
+++ b/src/main/python/rlbot/parsing/rlbot_config_parser.py
@@ -70,11 +70,12 @@ def parse_configurations(config_parser: ConfigObject, config_location, config_bu
         match_config.player_configs.append(player_config)
 
     extension_path = config_parser.get(RLBOT_CONFIGURATION_HEADER, EXTENSION_PATH_KEY)
-    if extension_path:
+    if extension_path and extension_path != 'None':  # The string 'None' ends up in people's config a lot.
         match_config.extension_config = ExtensionConfig()
         match_config.extension_config.python_file_path = extension_path
 
     return match_config
+
 
 def get_team(config, index):
     """

--- a/src/main/python/rlbot/version.py
+++ b/src/main/python/rlbot/version.py
@@ -4,14 +4,15 @@
 # 3) we can import it into your module module
 # https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
 
-__version__ = '1.12.1'
+__version__ = '1.12.2'
 
 release_notes = {
 
-    '1.12.1': """
+    '1.12.2': """
     - Support for passing an options dict to BotHelperProcesses. - tarehart
     - Python bots now wait until valid field info to call initialize_agent() - Marvin
     - Field info is no longer being updated each tick and is emptied out if we're not in a game. - Marvin and ccman32
+    - Making the details section of bot config files more visible to python GUIs. - tarehart
     """,
 
     '1.11.1': """


### PR DESCRIPTION
The config values are based on what @NicEastvillage added to the standard configs here: https://github.com/RLBot/RLBotPythonExample/pull/14

This will let me read the values from bundle.base_agent_config without getting an error about 'Details' not being a header. The error was happening even for bots who defined it in their config.

Also getting rid of an error message that tends to scare people.