### PR TITLE
Fix for serialization of multiline values in config files

### DIFF
--- a/src/main/python/rlbot/parsing/custom_config.py
+++ b/src/main/python/rlbot/parsing/custom_config.py
@@ -253,7 +253,8 @@ class ConfigHeader:
     def get_string(self, value_name):
         value = self.values[value_name]
         string = value.comment_description() + '\n'
-        string += value_name + ' = ' + str(value.get_value()) + '\n'
+        multiline_safe_value = str(value.get_value()).replace('\n', '\n\t')
+        string += value_name + ' = ' + multiline_safe_value + '\n'
         return string
 
 

--- a/src/main/python/rlbot/parsing/directory_scanner.py
+++ b/src/main/python/rlbot/parsing/directory_scanner.py
@@ -1,6 +1,6 @@
 import glob
 import os
-from configparser import NoSectionError, MissingSectionHeaderError, NoOptionError
+from configparser import NoSectionError, MissingSectionHeaderError, NoOptionError, ParsingError
 from typing import Set
 
 from rlbot.parsing.bot_config_bundle import BotConfigBundle, get_bot_config_bundle
@@ -19,7 +19,7 @@ def scan_directory_for_bot_configs(root_dir) -> Set[BotConfigBundle]:
         try:
             bundle = get_bot_config_bundle(filename)
             configs.add(bundle)
-        except (NoSectionError, MissingSectionHeaderError, NoOptionError, AttributeError):
+        except (NoSectionError, MissingSectionHeaderError, NoOptionError, AttributeError, ParsingError):
             pass
 
     return configs

--- a/src/main/python/rlbot/version.py
+++ b/src/main/python/rlbot/version.py
@@ -4,11 +4,11 @@
 # 3) we can import it into your module module
 # https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
 
-__version__ = '1.12.6'
+__version__ = '1.12.7'
 
 release_notes = {
 
-    '1.12.6': """
+    '1.12.7': """
     - Support for passing an options dict to BotHelperProcesses. - tarehart
     - Python bots now wait until valid field info to call initialize_agent() - Marvin
     - Field info is no longer being updated each tick and is emptied out if we're not in a game. - Marvin and ccman32
@@ -19,6 +19,7 @@ release_notes = {
     - Clear the screen when bots retire. - DomNomNom
     - Clear bot inputs when they retire. - DomNomNom
     - Improvements to the controller pass-through agent. - Kipje13 and chip
+    - Fix for serialization of multiline values in config files. - tarehart
     """,
 
     '1.11.1': """


### PR DESCRIPTION
Parsing this then writing it again resulted in the second line not being indented: https://github.com/RLBot/RLBotPythonExample/blob/master/python_example/python_example.cfg#L17-L18

Subsequent parsing of the config file fails.

Also catching the ParsingError which occurs from this in the directory scanner.