### PR TITLE
Making java wait for interface dll initialization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 }
 
 project.setGroup('org.rlbot.commons')
-project.setVersion('1.3.1')
+project.setVersion('1.3.2')
 
 def pythonRoot = './src/main/python/'
 

--- a/src/main/java/rlbot/cppinterop/RLBotDll.java
+++ b/src/main/java/rlbot/cppinterop/RLBotDll.java
@@ -39,8 +39,9 @@ public class RLBotDll {
     private static native ByteBufferStruct GetBallPrediction();
     private static native int SendQuickChat(Pointer ptr, int size);
     private static native int StartMatchFlatbuffer(Pointer ptr, int size);
-    private static native boolean IsInitialized();
+    private static native boolean IsInitialized();  // This asks the dll instance whether it is done initializing.
 
+    // This helps us keep track internally of whether we have initialized, so that we only do it once.
     private static boolean isInitializationComplete = false;
     private static final Object fileLock = new Object();
 

--- a/src/main/java/rlbot/cppinterop/RLBotDll.java
+++ b/src/main/java/rlbot/cppinterop/RLBotDll.java
@@ -39,6 +39,7 @@ public class RLBotDll {
     private static native ByteBufferStruct GetBallPrediction();
     private static native int SendQuickChat(Pointer ptr, int size);
     private static native int StartMatchFlatbuffer(Pointer ptr, int size);
+    private static native boolean IsInitialized();
 
     private static boolean isInitialized = false;
     private static final Object fileLock = new Object();
@@ -76,6 +77,14 @@ public class RLBotDll {
 
             System.out.println("Loading DLL from " + dllSource);
             Native.register(dllNameSansExtension);
+
+            while (!IsInitialized()) {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
 
             isInitialized = true;
         }

--- a/src/main/java/rlbot/cppinterop/RLBotDll.java
+++ b/src/main/java/rlbot/cppinterop/RLBotDll.java
@@ -41,12 +41,12 @@ public class RLBotDll {
     private static native int StartMatchFlatbuffer(Pointer ptr, int size);
     private static native boolean IsInitialized();
 
-    private static boolean isInitialized = false;
+    private static boolean isInitializationComplete = false;
     private static final Object fileLock = new Object();
 
     public static void initialize(final String interfaceDllPath) throws IOException {
         synchronized(fileLock) {
-            if (isInitialized) {
+            if (isInitializationComplete) {
                 return;
             }
 
@@ -78,15 +78,21 @@ public class RLBotDll {
             System.out.println("Loading DLL from " + dllSource);
             Native.register(dllNameSansExtension);
 
+            int attemptCount = 0;
             while (!IsInitialized()) {
                 try {
+                    attemptCount++;
+                    if (attemptCount > 100) {
+                        // Should throw after about 10 seconds of waiting.
+                        throw new IOException("The RLBot interface appears to be taking forever to initialize!");
+                    }
                     Thread.sleep(100);
                 } catch (InterruptedException e) {
                     e.printStackTrace();
                 }
             }
 
-            isInitialized = true;
+            isInitializationComplete = true;
         }
     }
 


### PR DESCRIPTION
Related pull request for core: https://github.com/skyborgff/rlbot-core/pull/46

Now is_match_ended will be a pretty reliable indicator. It becomes true after the replay of the final goal, right before the celebration phase.

Also includes an improvement to dll initialization for java bots that might fix a few issues.