### PR TITLE
Sending SIGTERM instead of CTRL_C_EVENT when subprocess agents retire.

### DIFF
--- a/src/main/python/rlbot/agents/base_subprocess_agent.py
+++ b/src/main/python/rlbot/agents/base_subprocess_agent.py
@@ -1,5 +1,5 @@
 from multiprocessing import Event
-from signal import CTRL_C_EVENT
+from signal import SIGTERM
 from subprocess import Popen
 
 import rlbot
@@ -36,5 +36,5 @@ class BaseSubprocessAgent(BaseIndependentAgent):
 
         # Block until we are asked to terminate, and then do so.
         terminate_request_event.wait()
-        process.send_signal(CTRL_C_EVENT)
+        process.send_signal(SIGTERM)
         process.wait()

--- a/src/main/python/rlbot/version.py
+++ b/src/main/python/rlbot/version.py
@@ -4,16 +4,17 @@
 # 3) we can import it into your module module
 # https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
 
-__version__ = '1.14.7'
+__version__ = '1.14.8'
 
 release_notes = {
-    '1.14.7': """
+    '1.14.8': """
     - Adding a way of starting matches using a flatbuffer message. - tarehart
     - More accurate get_output call frequency for python bots. - Marvin and chip
     - Fixing compilation of RLBotDotNet project with a breaking change. - tarehart
     - Pinning the psutil package to 5.5.0 to fix 'access denied', 'OSError'. - tarehart
     - Fixed for the friends update. - ccman32
     - Fix for psyonix bots never using boost. - tarehart
+    - Avoid killing the parent process, e.g. the GUI, when subprocess agents retire. - tarehart
     """,
 
     '1.13.2': """


### PR DESCRIPTION
This is designed to fix https://github.com/RLBot/RLBot/issues/386

Self-driving car was killing the GUI when it retired. SIGTERM appears not to have that issue.