### PR TITLE
Make the GUI allow non-vital cfg sections to be missing.

### DIFF
--- a/src/main/python/rlbot/gui/qt_root.py
+++ b/src/main/python/rlbot/gui/qt_root.py
@@ -393,7 +393,7 @@ class RLBotQTGui(QMainWindow, Ui_MainWindow):
             return
         raw_parser = configparser.RawConfigParser()
         raw_parser.read(config_path, encoding='utf8')
-        for section in self.overall_config.headers.keys():
+        for section in ['Match Configuration', 'Participant Configuration']:
             if not raw_parser.has_section(section):
                 self.popup_message(f"Config file is missing the section {section}, not loading it!",
                                    "Invalid Config File", QMessageBox.Warning)

--- a/src/main/python/rlbot/version.py
+++ b/src/main/python/rlbot/version.py
@@ -4,10 +4,10 @@
 # 3) we can import it into your module module
 # https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
 
-__version__ = '1.14.8'
+__version__ = '1.14.9'
 
 release_notes = {
-    '1.14.8': """
+    '1.14.9': """
     - Adding a way of starting matches using a flatbuffer message. - tarehart
     - More accurate get_output call frequency for python bots. - Marvin and chip
     - Fixing compilation of RLBotDotNet project with a breaking change. - tarehart
@@ -15,6 +15,7 @@ release_notes = {
     - Fixed for the friends update. - ccman32
     - Fix for psyonix bots never using boost. - tarehart
     - Avoid killing the parent process, e.g. the GUI, when subprocess agents retire. - tarehart
+    - Make the GUI allow non-vital cfg sections to be missing. - tarehart
     """,
 
     '1.13.2': """


### PR DESCRIPTION
Use case: I want to use cleopetra to generate a rlbot.cfg for a tournament match, then run run-gui.bat to tweak some things before running the match. However, the GUI complains that 

> Config file is missing the section RLBot Configuration, not loading it!

Which is true. I'm guessing that the cleopetra technique for generating the cfg omits sections that are empty. But, that section is not vital. After removing the warning, the GUI operates fine and can run the match.