### PR TITLE
Add `__getitem___` to SimpleControllerState

### DIFF
--- a/src/main/python/rlbot/agents/base_agent.py
+++ b/src/main/python/rlbot/agents/base_agent.py
@@ -50,6 +50,9 @@ class SimpleControllerState:
         self.jump = jump
         self.boost = boost
         self.handbrake = handbrake
+        
+     def __getitem__(self, key):
+        return self[key]
 
 
 class BaseAgent:


### PR DESCRIPTION
This just adds `__getitem__` so you can `SimpleControllerState()["pitch"]` instead of `SimpleControllerState().pitch`