### PR TITLE
Botmanager py36 fix

### DIFF
--- a/src/main/python/rlbot/botmanager/bot_manager.py
+++ b/src/main/python/rlbot/botmanager/bot_manager.py
@@ -27,6 +27,13 @@ REFRESH_NOT_IN_PROGRESS = 0
 MAX_CARS = 10
 
 
+# Backward compatibility with Python 3.6:
+try:
+    time.perf_counter_ns()
+except AttributeError:
+    time.perf_counter_ns = lambda: time.perf_counter() * 1e9
+
+
 class BotManager:
 
     def __init__(self, terminate_request_event, termination_complete_event, reload_request_event, bot_configuration,


### PR DESCRIPTION
This should fix the backward incompatibility with Python 3.6 that my previous PR introduced.