### PR TITLE
Allowing python bots to configure their preferred maximum tick rate.

### DIFF
--- a/src/main/python/rlbot/agents/base_agent.py
+++ b/src/main/python/rlbot/agents/base_agent.py
@@ -22,6 +22,7 @@ LOGO_FILE_KEY = 'logo_file'
 LOOKS_CONFIG_KEY = 'looks_config'
 BOT_NAME_KEY = "name"
 SUPPORTS_EARLY_START_KEY = "supports_early_start"
+MAXIMUM_TICK_RATE_PREFERENCE_KEY = "maximum_tick_rate_preference"
 
 
 class SimpleControllerState:
@@ -300,6 +301,8 @@ class BaseAgent:
                                   description="Location of an image file to use as your bot's logo")
         location_config.add_value(SUPPORTS_EARLY_START_KEY, bool,
                                   description="True if this bot can be started before the Rocket League match begins.")
+        location_config.add_value(MAXIMUM_TICK_RATE_PREFERENCE_KEY, int, default=60,
+                                  description="The maximum number of ticks per second that your bot wishes to receive.")
 
         details_config = config.add_header_name(BOT_CONFIG_DETAILS_HEADER)
         details_config.add_value('developer', str, description="Name of the bot's creator/developer")

--- a/src/test/python/agents/atba/atba.cfg
+++ b/src/test/python/agents/atba/atba.cfg
@@ -6,6 +6,7 @@ looks_config = ./atba_looks.cfg
 python_file = atba.py
 # The name that will be displayed in game
 name = AlwaysTowardsBallAgent
+maximum_tick_rate_preference = 120
 
 [Bot Parameters]
 # if true bot will turn opposite way


### PR DESCRIPTION
I want to give python bots the ability to specify their maximum_tick_rate_preference.

If they set maximum_tick_rate_preference = 60 then get_output will get called at most 60 times per second.

I intend to:
- Set this value to 60 by default
- Inform our power users who want 120 that they need to update their .cfg file

This is a sensible default because the majority of our bot makers have been developing and testing on 60 Hz. I'm confident of this because few people even know how to find and modify TARLBot.ini to achieve 120.

I've tested this code pretty well. When the setting is 120, I've never observed the bot manager skipping a frame. The in-game percentages overlay responds as expected. If you set maximum_tick_rate_preference = 12, it shows a steady 10% when RLBot.exe is updating data at 120.

I'll update version.py properly in the closed source repo; this branch is a bit out of date.