### PR TITLE
Updating the Java bot manager to use the new fresh packet feature.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 }
 
 project.setGroup('org.rlbot.commons')
-project.setVersion('1.9.1')
+project.setVersion('1.10.0')
 
 def pythonRoot = './src/main/python/'
 

--- a/src/main/java/rlbot/render/Renderer.java
+++ b/src/main/java/rlbot/render/Renderer.java
@@ -72,6 +72,8 @@ public abstract class Renderer {
 
     /**
      * Draws a line in screen coordinates.
+     *
+     * @deprecated We unfortunately don't support 2d lines anymore!
      */
     public void drawLine2d(java.awt.Color color, Point start, Point end) {
 
@@ -106,6 +108,8 @@ public abstract class Renderer {
 
     /**
      * Draws a 2D line which starts at screen coordinates and ends at a 3D coordinate.
+     *
+     * @deprecated We unfortunately don't support 2d3d lines anymore!
      */
     public void drawLine2d3d(java.awt.Color color, Point start, rlbot.vector.Vector3 end) {
 
@@ -122,6 +126,8 @@ public abstract class Renderer {
     }
 
     /**
+     * WARNING: setting filled=false no longer works!
+     *
      * This draws a 2D rectangle in screen coordinates.
      * @param upperLeft The upper left corner of the rectangle.
      * @param width in pixels.
@@ -145,6 +151,8 @@ public abstract class Renderer {
     }
 
     /**
+     * WARNING: setting filled=false no longer works!
+     *
      * This draws a 2D rectangle at a 3D-tracked position.
      * @param upperLeft The upper left corner of the rectangle.
      * @param width in pixels.
@@ -156,6 +164,8 @@ public abstract class Renderer {
     }
 
     /**
+     * WARNING: setting filled=false no longer works!
+     *
      * This draws a 2D rectangle at a 3D-tracked position.
      * @param position The center of the rectangle.
      * @param width in pixels.

--- a/src/test/java/rlbot/JavaExample.java
+++ b/src/test/java/rlbot/JavaExample.java
@@ -17,6 +17,7 @@ public class JavaExample {
         }
 
         BotManager flatBotManager = new BotManager();
+        flatBotManager.setRefreshRate(120);
         Integer port = Integer.parseInt(args[0]);
         SocketServer server = new SamplePythonInterface(port, flatBotManager);
         server.start();

--- a/src/test/java/rlbot/SampleBot.java
+++ b/src/test/java/rlbot/SampleBot.java
@@ -13,30 +13,20 @@ import rlbot.input.DropshotTile;
 import rlbot.input.FieldInfoManager;
 import rlbot.manager.BotLoopRenderer;
 import rlbot.output.ControlsOutput;
-import rlbot.render.NamedRenderer;
 import rlbot.render.Renderer;
 import rlbot.vec.Vector2;
 
-import java.awt.*;
 import java.awt.Color;
 import java.io.IOException;
 
 public class SampleBot extends BaseBot {
 
-    private final NamedRenderer triangleRenderer;
     private FieldInfoManager fieldInfoManager = new FieldInfoManager();
 
     public SampleBot(int playerIndex, int team) {
         super(playerIndex, team);
 
         System.out.println("Constructed sample bot " + playerIndex);
-
-        triangleRenderer = new NamedRenderer("Triangle" + playerIndex);
-        triangleRenderer.startPacket();
-        triangleRenderer.drawLine2d(Color.cyan, new Point(50, 50), new Point(20, 80));
-        triangleRenderer.drawLine2d(Color.cyan, new Point(20, 80), new Point(80, 80));
-        triangleRenderer.drawLine2d(Color.cyan, new Point(50, 50), new Point(80, 80));
-        triangleRenderer.finishAndSend();
     }
 
     private ControlsOutput processInput(DataPacket input) {
@@ -93,10 +83,6 @@ public class SampleBot extends BaseBot {
             e.printStackTrace();
         }
 
-        if (input.ball.position.z > 1000) {
-            triangleRenderer.eraseFromScreen();
-        }
-
         try {
             final BallPrediction ballPrediction = RLBotDll.getBallPrediction();
 
@@ -110,7 +96,7 @@ public class SampleBot extends BaseBot {
         return new ControlsOutput()
                 .withSteer(steer)
                 .withThrottle(1)
-                .withUseItem(steer > 0);
+                .withUseItem(myCar.velocity.y > 0);
     }
 
     @Override


### PR DESCRIPTION
This will result in *extreme freshness*. The new packet should be delivered to java bots within a millisecond after it is made available by RLBot.exe.

This will theoretically improve the consistency and reaction time of bots. Certain things like kickoffs may need to be re-tuned by bot makers, even if they don't opt-in to 120Hz.

The specific logic was in the bot manager worked out in collaboration with Parzival.

I'm not concerned by pushing this right before the Lightfall tournament because this will not affect any bots until they are recompiled with this new code. If anybody wants to opt-out, they can set their dependency to 1.9.1: https://github.com/RLBot/RLBotJavaExample/blob/master/build.gradle#L22