### PR TITLE
Updating python bot manager to use fresh packet function.

### DIFF
--- a/src/main/python/rlbot/botmanager/bot_manager_flatbuffer.py
+++ b/src/main/python/rlbot/botmanager/bot_manager_flatbuffer.py
@@ -28,7 +28,9 @@ class BotManagerFlatbuffer(BotManager):
             return 0.0
 
     def pull_data_from_game(self):
-        self.game_tick_flat_binary = self.game_interface.get_live_data_flat_binary()
+        # Set a timeout of 30 milliseconds. It's slightly less than the number of milliseconds (33.33)
+        # caused by MAX_AGENT_CALL_PERIOD defined in bot_manager.py
+        self.game_tick_flat_binary = self.game_interface.get_fresh_live_data_flat_binary(30, self.index)
         if self.game_tick_flat_binary is not None:
             self.game_tick_flat = GameTickPacket.GameTickPacket.GetRootAsGameTickPacket(self.game_tick_flat_binary, 0)
 

--- a/src/main/python/rlbot/botmanager/bot_manager_struct.py
+++ b/src/main/python/rlbot/botmanager/bot_manager_struct.py
@@ -63,7 +63,9 @@ class BotManagerStruct(BotManager):
         return self.game_tick_packet.game_info.seconds_elapsed
 
     def pull_data_from_game(self):
-        self.game_interface.update_live_data_packet(self.game_tick_packet)
+        # Set a timeout of 30 milliseconds. It's slightly less than the number of milliseconds (33.33)
+        # caused by MAX_AGENT_CALL_PERIOD defined in bot_manager.py
+        self.game_interface.fresh_live_data_packet(self.game_tick_packet, 30, self.index)
 
     def get_ball_prediction_struct(self):
         return self.game_interface.update_ball_prediction(self.ball_prediction)

--- a/src/main/python/rlbot/version.py
+++ b/src/main/python/rlbot/version.py
@@ -4,14 +4,15 @@
 # 3) we can import it into your module module
 # https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
 
-__version__ = '1.30.0'
+__version__ = '1.30.1'
 
 release_notes = {
-    '1.30.0': """
+    '1.30.1': """
     Kipje13 has a major speedup for rendering in python! You'll get the benefits
     automatically, but ask him for the details if you're curious.
     
-    Also laying the groundwork for fresher game ticks.
+    Also delivering fresher packets to python bots, for improved latency and
+    consistency. This may affect bot behavior slightly, check your kickoffs!
     """,
     '1.29.0': """
     Python bots will now be able to specify their preferred tick rate. Do you like running at 120Hz?

--- a/src/test/python/agents/flatBot/flatBot.cfg
+++ b/src/test/python/agents/flatBot/flatBot.cfg
@@ -7,3 +7,5 @@ python_file = flatBot.py
 
 # Name that will be displayed in game
 name = FlatBot
+
+maximum_tick_rate_preference = 120


### PR DESCRIPTION
This will result in extreme freshness. The new packet should be delivered to python bots within a millisecond after it is made available by RLBot.exe. This is similar to https://github.com/RLBot/RLBot/pull/457

This will theoretically improve the consistency and reaction time of bots. Certain things like kickoffs may need to be re-tuned by bot makers, even if they don't opt-in to 120Hz.

Unfortunately it is impossible to opt out of the *freshness* except by pinning your RLBot pip version to 1.30.0. If we see evidence that kickoffs are suffering, we can discuss ways to deal with that for the upcoming tournament.