### PR TITLE
Fixed bug that led to a WrongProcessArgs error even though the args were correct.

### DIFF
--- a/src/main/python/rlbot/utils/process_configuration.py
+++ b/src/main/python/rlbot/utils/process_configuration.py
@@ -96,7 +96,7 @@ def is_process_running(program, scriptname, required_args: Set[str]):
                 try:
                     args = process.cmdline()[1:]
                     for required_arg in required_args:
-                        matching_args = [arg for arg in args if re.match(required_arg, arg) is not None]
+                        matching_args = [arg for arg in args if re.match(required_arg, arg, flags=re.IGNORECASE) is not None]
                         if len(matching_args) == 0:
                             raise WrongProcessArgs(f"{program} is not running with {required_arg}!")
                 except psutil.AccessDenied:


### PR DESCRIPTION
Fixed by: 

- using case-insensitive match for process arguments
- checking all matching processes, not just the first one

The first commit should be enough to fix it, but I think it is still a good idea to check all matching processes rather than just the first one that we find.