### PR TITLE
Add an exception for when Rocket League is not running after the game interface has already been initialised

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -462,7 +462,7 @@ ASALocalRun/
 src/main/cs/RLBotControllerSample/CopyFilesFromSrc.bat
 
 # VSCode IDE files.
-src/main/cpp/RLBotInterface/.vscode/
+**/.vscode/
 
 # CMake generated project files
 build64/

--- a/src/main/python/rlbot/utils/process_configuration.py
+++ b/src/main/python/rlbot/utils/process_configuration.py
@@ -96,7 +96,7 @@ def is_process_running(program, scriptname, required_args: Set[str]):
                 try:
                     args = process.cmdline()[1:]
                     for required_arg in required_args:
-                        matching_args = [arg for arg in args if re.match(required_arg, arg) is not None]
+                        matching_args = [arg for arg in args if re.match(required_arg, arg, flags=re.IGNORECASE) is not None]
                         if len(matching_args) == 0:
                             raise WrongProcessArgs(f"{program} is not running with {required_arg}!")
                 except psutil.AccessDenied:


### PR DESCRIPTION
Rewrote the `connect_to_game` method and added an `is_rocket_league_running` method to catch when Rocket League is not running and we had started once already.

My motivation for this was that I was getting another error which made no sense when really what was wrong was the situation described above.

I also generalised the gitignore to ignore `.vscode/` folders anywhere (not just in src/main/cpp/RLBotInterface).