### PR TITLE
 Adding Psyonix bot presets. 

### DIFF
--- a/src/main/python/rlbot/matchconfig/conversions.py
+++ b/src/main/python/rlbot/matchconfig/conversions.py
@@ -55,17 +55,9 @@ def parse_match_config(
     for i in range(num_players):
 
         config_bundle = config_bundles[i]
-        bot_type = config_parser.get(PARTICIPANT_CONFIGURATION_HEADER, PARTICIPANT_TYPE_KEY, i)
 
         if i not in looks_config_overrides:
-            if bot_type == "psyonix":
-                # choose a random preset for psyonix bots
-                preset_directory = Path(__file__).parent / "psyonix_presets"
-                looks_path = random.choice(list(preset_directory.glob("*.cfg")))
-                looks_config_object = create_looks_configurations().parse_file(looks_path)
-                config_bundle.name = looks_path.name.split("_")[1].title()
-            else:
-                looks_config_object = config_bundle.get_looks_config()
+            looks_config_object = config_bundle.get_looks_config()
         else:
             looks_config_object = looks_config_overrides[i]
 

--- a/src/main/python/rlbot/matchconfig/conversions.py
+++ b/src/main/python/rlbot/matchconfig/conversions.py
@@ -1,17 +1,9 @@
 import json
-import random
 from pathlib import Path
 
 from rlbot.matchconfig.loadout_config import LoadoutConfig, LoadoutPaintConfig
 from rlbot.matchconfig.match_config import MatchConfig, ExtensionConfig, MutatorConfig, PlayerConfig
-from rlbot.parsing.agent_config_parser import (
-    PARTICIPANT_CONFIGURATION_HEADER,
-    PARTICIPANT_TEAM,
-    PARTICIPANT_TYPE_KEY,
-    load_bot_appearance,
-    PARTICIPANT_BOT_SKILL_KEY,
-    create_looks_configurations,
-)
+from rlbot.parsing.agent_config_parser import PARTICIPANT_CONFIGURATION_HEADER, PARTICIPANT_TEAM, PARTICIPANT_TYPE_KEY, load_bot_appearance, PARTICIPANT_BOT_SKILL_KEY
 from rlbot.parsing.bot_config_bundle import BotConfigBundle, get_bot_config_bundles
 from rlbot.parsing.custom_config import ConfigObject
 from rlbot.parsing.incrementing_integer import IncrementingInteger
@@ -32,9 +24,8 @@ def read_match_config_from_file(match_config_path: Path) -> MatchConfig:
     return parse_match_config(config_obj, match_config_path, {}, {})
 
 
-def parse_match_config(
-    config_parser: ConfigObject, config_location, config_bundle_overrides, looks_config_overrides
-) -> MatchConfig:
+def parse_match_config(config_parser: ConfigObject, config_location, config_bundle_overrides,
+                       looks_config_overrides) -> MatchConfig:
 
     match_config = MatchConfig()
     match_config.mutators = MutatorConfig()
@@ -66,7 +57,7 @@ def parse_match_config(
         match_config.player_configs.append(player_config)
 
     extension_path = config_parser.get(RLBOT_CONFIGURATION_HEADER, EXTENSION_PATH_KEY)
-    if extension_path and extension_path != "None":  # The string 'None' ends up in people's config a lot.
+    if extension_path and extension_path != 'None':  # The string 'None' ends up in people's config a lot.
         match_config.extension_config = ExtensionConfig()
         match_config.extension_config.python_file_path = extension_path
 
@@ -84,16 +75,16 @@ def get_team(config, index):
 
 
 def get_bot_options(bot_type):
-    if bot_type == "human":
+    if bot_type == 'human':
         is_bot = False
         is_rlbot = False
-    elif bot_type == "rlbot":
+    elif bot_type == 'rlbot':
         is_bot = True
         is_rlbot = True
-    elif bot_type == "psyonix":
+    elif bot_type == 'psyonix':
         is_bot = True
         is_rlbot = False
-    elif bot_type == "party_member_bot":
+    elif bot_type == 'party_member_bot':
         # this is a bot running under a human
 
         is_rlbot = True
@@ -104,13 +95,9 @@ def get_bot_options(bot_type):
     return is_bot, is_rlbot
 
 
-def _load_bot_config(
-    index,
-    config_bundle: BotConfigBundle,
-    looks_config_object: ConfigObject,
-    overall_config: ConfigObject,
-    human_index_tracker: IncrementingInteger,
-) -> PlayerConfig:
+def _load_bot_config(index, config_bundle: BotConfigBundle,
+                     looks_config_object: ConfigObject, overall_config: ConfigObject,
+                     human_index_tracker: IncrementingInteger) -> PlayerConfig:
     """
     Loads the config data of a single bot
     :param index: This is the bot index (where it appears in game_cars)
@@ -132,8 +119,7 @@ def _load_bot_config(
     bot_type = overall_config.get(PARTICIPANT_CONFIGURATION_HEADER, PARTICIPANT_TYPE_KEY, index)
     bot_configuration.bot, bot_configuration.rlbot_controlled = get_bot_options(bot_type)
     bot_configuration.bot_skill = overall_config.getfloat(
-        PARTICIPANT_CONFIGURATION_HEADER, PARTICIPANT_BOT_SKILL_KEY, index
-    )
+        PARTICIPANT_CONFIGURATION_HEADER, PARTICIPANT_BOT_SKILL_KEY, index)
 
     if not bot_configuration.bot:
         bot_configuration.human_index = human_index_tracker.increment()
@@ -150,13 +136,14 @@ def _load_bot_config(
 # ====== MatchConfig -> JSON ======
 # The JSON conversion serializes and deserializes MatchConfig in its entirety,
 # including player config which is usually specified in different files.
+
 known_types = {
-    MatchConfig: "__MatchConfig__",
-    MutatorConfig: "__MutatorConfig__",
-    ExtensionConfig: "__ExtensionConfig__",
-    PlayerConfig: "__PlayerConfig__",
-    LoadoutConfig: "__LoadoutConfig__",
-    LoadoutPaintConfig: "__LoadoutPaintConfig__",
+    MatchConfig: '__MatchConfig__',
+    MutatorConfig: '__MutatorConfig__',
+    ExtensionConfig: '__ExtensionConfig__',
+    PlayerConfig: '__PlayerConfig__',
+    LoadoutConfig: '__LoadoutConfig__',
+    LoadoutPaintConfig: '__LoadoutPaintConfig__',
 }
 
 
@@ -171,8 +158,9 @@ class ConfigJsonEncoder(json.JSONEncoder):
         # Let the base class default method raise the TypeError
         return json.JSONEncoder.default(self, obj)
 
-
 # ====== JSON -> MatchConfig ======
+
+
 def as_match_config(json_obj) -> MatchConfig:
     for cls, tag in known_types.items():
         if not json_obj.get(tag, False):

--- a/src/main/python/rlbot/matchconfig/psyonix_config.py
+++ b/src/main/python/rlbot/matchconfig/psyonix_config.py
@@ -1,0 +1,19 @@
+import random
+from pathlib import Path
+
+from rlbot.matchconfig.match_config import PlayerConfig
+from rlbot.parsing.agent_config_parser import load_bot_appearance, create_looks_configurations
+
+PSYONIX_PRESET_DIRECTORY = Path(__file__).parent / "psyonix_presets"
+PSYONIX_PRESET_LIST = list(PSYONIX_PRESET_DIRECTORY.glob("*.cfg"))
+
+
+def set_random_psyonix_bot_preset(player: PlayerConfig):
+    """
+    Sets the name and loadout to a randomly selected psyonix bot preset.
+    """
+    loadout_file = random.choice(PSYONIX_PRESET_LIST)
+    loadout_config = create_looks_configurations().parse_file(loadout_file)
+    player.loadout_config = load_bot_appearance(loadout_config, player.team)
+    player.name = loadout_file.name.split("_")[1].title()
+    player.name = ["Rookie", "Pro", ""][min(int(abs(player.bot_skill) * 3), 2)] + " " + player.name

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/bombers_casper_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/bombers_casper_appearance.cfg
@@ -1,21 +1,15 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 25
 decal_id = 322
 wheels_id = 377
 boost_id = 67
-antenna_id = 0
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 25
 decal_id = 322
 wheels_id = 377
 boost_id = 67
-antenna_id = 0
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/bombers_casper_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/bombers_casper_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 25
+decal_id = 322
+wheels_id = 377
+boost_id = 67
+antenna_id = 0
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 25
+decal_id = 322
+wheels_id = 377
+boost_id = 67
+antenna_id = 0
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/bombers_marley_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/bombers_marley_appearance.cfg
@@ -1,21 +1,17 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 21
 decal_id = 290
 wheels_id = 365
 boost_id = 63
-antenna_id = 0
 hat_id = 232
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 21
 decal_id = 290
 wheels_id = 365
 boost_id = 63
-antenna_id = 0
 hat_id = 232
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/bombers_marley_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/bombers_marley_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 21
+decal_id = 290
+wheels_id = 365
+boost_id = 63
+antenna_id = 0
+hat_id = 232
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 21
+decal_id = 290
+wheels_id = 365
+boost_id = 63
+antenna_id = 0
+hat_id = 232
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/bombers_myrtle_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/bombers_myrtle_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 23
+decal_id = 308
+wheels_id = 377
+boost_id = 67
+antenna_id = 0
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 23
+decal_id = 308
+wheels_id = 377
+boost_id = 67
+antenna_id = 0
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/bombers_myrtle_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/bombers_myrtle_appearance.cfg
@@ -1,21 +1,15 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 23
 decal_id = 308
 wheels_id = 377
 boost_id = 67
-antenna_id = 0
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 23
 decal_id = 308
 wheels_id = 377
 boost_id = 67
-antenna_id = 0
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/bombers_samara_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/bombers_samara_appearance.cfg
@@ -1,21 +1,15 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 24
 decal_id = 315
 wheels_id = 377
 boost_id = 67
-antenna_id = 0
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 24
 decal_id = 315
 wheels_id = 377
 boost_id = 67
-antenna_id = 0
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/bombers_samara_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/bombers_samara_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 24
+decal_id = 315
+wheels_id = 377
+boost_id = 67
+antenna_id = 0
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 24
+decal_id = 315
+wheels_id = 377
+boost_id = 67
+antenna_id = 0
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/cyclones_fury_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/cyclones_fury_appearance.cfg
@@ -1,21 +1,15 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 30
 decal_id = 346
 wheels_id = 381
 boost_id = 64
-antenna_id = 0
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 30
 decal_id = 346
 wheels_id = 381
 boost_id = 64
-antenna_id = 0
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/cyclones_fury_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/cyclones_fury_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 30
+decal_id = 346
+wheels_id = 381
+boost_id = 64
+antenna_id = 0
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 30
+decal_id = 346
+wheels_id = 381
+boost_id = 64
+antenna_id = 0
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/cyclones_rainmaker_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/cyclones_rainmaker_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 23
+decal_id = 303
+wheels_id = 381
+boost_id = 33
+antenna_id = 0
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 23
+decal_id = 303
+wheels_id = 381
+boost_id = 33
+antenna_id = 0
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/cyclones_rainmaker_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/cyclones_rainmaker_appearance.cfg
@@ -1,21 +1,15 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 23
 decal_id = 303
 wheels_id = 381
 boost_id = 33
-antenna_id = 0
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 23
 decal_id = 303
 wheels_id = 381
 boost_id = 33
-antenna_id = 0
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/cyclones_squall_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/cyclones_squall_appearance.cfg
@@ -1,21 +1,15 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 24
 decal_id = 310
 wheels_id = 381
 boost_id = 69
-antenna_id = 0
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 24
 decal_id = 310
 wheels_id = 381
 boost_id = 69
-antenna_id = 0
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/cyclones_squall_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/cyclones_squall_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 24
+decal_id = 310
+wheels_id = 381
+boost_id = 69
+antenna_id = 0
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 24
+decal_id = 310
+wheels_id = 381
+boost_id = 69
+antenna_id = 0
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/cyclones_storm_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/cyclones_storm_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 30
+decal_id = 346
+wheels_id = 381
+boost_id = 61
+antenna_id = 0
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 30
+decal_id = 346
+wheels_id = 381
+boost_id = 61
+antenna_id = 0
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/cyclones_storm_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/cyclones_storm_appearance.cfg
@@ -1,21 +1,15 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 30
 decal_id = 346
 wheels_id = 381
 boost_id = 61
-antenna_id = 0
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 30
 decal_id = 346
 wheels_id = 381
 boost_id = 61
-antenna_id = 0
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/dragons_hound_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/dragons_hound_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 25
+decal_id = 316
+wheels_id = 372
+boost_id = 63
+antenna_id = 0
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 25
+decal_id = 316
+wheels_id = 372
+boost_id = 63
+antenna_id = 0
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/dragons_hound_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/dragons_hound_appearance.cfg
@@ -1,21 +1,15 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 25
 decal_id = 316
 wheels_id = 372
 boost_id = 63
-antenna_id = 0
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 25
 decal_id = 316
 wheels_id = 372
 boost_id = 63
-antenna_id = 0
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/dragons_imp_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/dragons_imp_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 26
+decal_id = 327
+wheels_id = 369
+boost_id = 63
+antenna_id = 0
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 26
+decal_id = 327
+wheels_id = 369
+boost_id = 63
+antenna_id = 0
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/dragons_imp_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/dragons_imp_appearance.cfg
@@ -1,21 +1,15 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 26
 decal_id = 327
 wheels_id = 369
 boost_id = 63
-antenna_id = 0
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 26
 decal_id = 327
 wheels_id = 369
 boost_id = 63
-antenna_id = 0
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/dragons_mountain_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/dragons_mountain_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 30
+decal_id = 347
+wheels_id = 365
+boost_id = 36
+antenna_id = 0
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 30
+decal_id = 347
+wheels_id = 365
+boost_id = 36
+antenna_id = 0
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/dragons_mountain_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/dragons_mountain_appearance.cfg
@@ -1,21 +1,15 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 30
 decal_id = 347
 wheels_id = 365
 boost_id = 36
-antenna_id = 0
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 30
 decal_id = 347
 wheels_id = 365
 boost_id = 36
-antenna_id = 0
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/dragons_viper_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/dragons_viper_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 31
+decal_id = 354
+wheels_id = 363
+boost_id = 55
+antenna_id = 13
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 31
+decal_id = 354
+wheels_id = 363
+boost_id = 55
+antenna_id = 13
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/dragons_viper_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/dragons_viper_appearance.cfg
@@ -1,21 +1,17 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 31
 decal_id = 354
 wheels_id = 363
 boost_id = 55
 antenna_id = 13
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 31
 decal_id = 354
 wheels_id = 363
 boost_id = 55
 antenna_id = 13
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/express_beast_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/express_beast_appearance.cfg
@@ -1,21 +1,15 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 25
 decal_id = 320
 wheels_id = 375
 boost_id = 41
-antenna_id = 0
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 25
 decal_id = 320
 wheels_id = 375
 boost_id = 41
-antenna_id = 0
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/express_beast_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/express_beast_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 25
+decal_id = 320
+wheels_id = 375
+boost_id = 41
+antenna_id = 0
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 25
+decal_id = 320
+wheels_id = 375
+boost_id = 41
+antenna_id = 0
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/express_roundhouse_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/express_roundhouse_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 25
+decal_id = 316
+wheels_id = 365
+boost_id = 58
+antenna_id = 0
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 25
+decal_id = 316
+wheels_id = 365
+boost_id = 58
+antenna_id = 0
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/express_roundhouse_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/express_roundhouse_appearance.cfg
@@ -1,21 +1,15 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 25
 decal_id = 316
 wheels_id = 365
 boost_id = 58
-antenna_id = 0
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 25
 decal_id = 316
 wheels_id = 365
 boost_id = 58
-antenna_id = 0
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/express_sabertooth_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/express_sabertooth_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 29
+decal_id = 339
+wheels_id = 375
+boost_id = 41
+antenna_id = 0
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 29
+decal_id = 339
+wheels_id = 375
+boost_id = 41
+antenna_id = 0
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/express_sabertooth_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/express_sabertooth_appearance.cfg
@@ -1,21 +1,15 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 29
 decal_id = 339
 wheels_id = 375
 boost_id = 41
-antenna_id = 0
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 29
 decal_id = 339
 wheels_id = 375
 boost_id = 41
-antenna_id = 0
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/express_tusk_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/express_tusk_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 30
+decal_id = 347
+wheels_id = 375
+boost_id = 41
+antenna_id = 0
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 30
+decal_id = 347
+wheels_id = 375
+boost_id = 41
+antenna_id = 0
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/express_tusk_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/express_tusk_appearance.cfg
@@ -1,21 +1,15 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 30
 decal_id = 347
 wheels_id = 375
 boost_id = 41
-antenna_id = 0
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 30
 decal_id = 347
 wheels_id = 375
 boost_id = 41
-antenna_id = 0
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/guardians_c-block_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/guardians_c-block_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 24
+decal_id = 315
+wheels_id = 380
+boost_id = 50
+antenna_id = 0
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 24
+decal_id = 315
+wheels_id = 380
+boost_id = 50
+antenna_id = 0
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/guardians_c-block_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/guardians_c-block_appearance.cfg
@@ -1,21 +1,15 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 24
 decal_id = 315
 wheels_id = 380
 boost_id = 50
-antenna_id = 0
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 24
 decal_id = 315
 wheels_id = 380
 boost_id = 50
-antenna_id = 0
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/guardians_centice_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/guardians_centice_appearance.cfg
@@ -1,21 +1,15 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 26
 decal_id = 327
 wheels_id = 380
 boost_id = 45
-antenna_id = 0
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 26
 decal_id = 327
 wheels_id = 380
 boost_id = 45
-antenna_id = 0
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/guardians_centice_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/guardians_centice_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 26
+decal_id = 327
+wheels_id = 380
+boost_id = 45
+antenna_id = 0
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 26
+decal_id = 327
+wheels_id = 380
+boost_id = 45
+antenna_id = 0
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/guardians_gerwin_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/guardians_gerwin_appearance.cfg
@@ -1,21 +1,15 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 23
 decal_id = 305
 wheels_id = 380
 boost_id = 48
-antenna_id = 0
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 23
 decal_id = 305
 wheels_id = 380
 boost_id = 48
-antenna_id = 0
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/guardians_gerwin_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/guardians_gerwin_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 23
+decal_id = 305
+wheels_id = 380
+boost_id = 48
+antenna_id = 0
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 23
+decal_id = 305
+wheels_id = 380
+boost_id = 48
+antenna_id = 0
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/guardians_junker_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/guardians_junker_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 28
+decal_id = 332
+wheels_id = 380
+boost_id = 49
+antenna_id = 0
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 28
+decal_id = 332
+wheels_id = 380
+boost_id = 49
+antenna_id = 0
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/guardians_junker_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/guardians_junker_appearance.cfg
@@ -1,21 +1,15 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 28
 decal_id = 332
 wheels_id = 380
 boost_id = 49
-antenna_id = 0
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 28
 decal_id = 332
 wheels_id = 380
 boost_id = 49
-antenna_id = 0
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/mammoths_boomer_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/mammoths_boomer_appearance.cfg
@@ -1,21 +1,15 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 21
 decal_id = 292
 wheels_id = 367
 boost_id = 58
-antenna_id = 0
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 21
 decal_id = 292
 wheels_id = 367
 boost_id = 58
-antenna_id = 0
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/mammoths_boomer_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/mammoths_boomer_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 21
+decal_id = 292
+wheels_id = 367
+boost_id = 58
+antenna_id = 0
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 21
+decal_id = 292
+wheels_id = 367
+boost_id = 58
+antenna_id = 0
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/mammoths_caveman_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/mammoths_caveman_appearance.cfg
@@ -1,21 +1,15 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 30
 decal_id = 347
 wheels_id = 360
 boost_id = 53
-antenna_id = 0
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 30
 decal_id = 347
 wheels_id = 360
 boost_id = 53
-antenna_id = 0
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/mammoths_caveman_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/mammoths_caveman_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 30
+decal_id = 347
+wheels_id = 360
+boost_id = 53
+antenna_id = 0
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 30
+decal_id = 347
+wheels_id = 360
+boost_id = 53
+antenna_id = 0
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/mammoths_foamer_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/mammoths_foamer_appearance.cfg
@@ -1,21 +1,15 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 29
 decal_id = 340
 wheels_id = 367
 boost_id = 58
-antenna_id = 0
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 29
 decal_id = 340
 wheels_id = 367
 boost_id = 58
-antenna_id = 0
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/mammoths_foamer_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/mammoths_foamer_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 29
+decal_id = 340
+wheels_id = 367
+boost_id = 58
+antenna_id = 0
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 29
+decal_id = 340
+wheels_id = 367
+boost_id = 58
+antenna_id = 0
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/mammoths_sticks_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/mammoths_sticks_appearance.cfg
@@ -1,21 +1,15 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 23
 decal_id = 308
 wheels_id = 367
 boost_id = 58
-antenna_id = 0
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 23
 decal_id = 308
 wheels_id = 367
 boost_id = 58
-antenna_id = 0
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/mammoths_sticks_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/mammoths_sticks_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 23
+decal_id = 308
+wheels_id = 367
+boost_id = 58
+antenna_id = 0
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 23
+decal_id = 308
+wheels_id = 367
+boost_id = 58
+antenna_id = 0
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/monarchs_khan_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/monarchs_khan_appearance.cfg
@@ -1,21 +1,17 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 29
 decal_id = 340
 wheels_id = 383
 boost_id = 37
-antenna_id = 0
 hat_id = 228
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 29
 decal_id = 340
 wheels_id = 383
 boost_id = 37
-antenna_id = 0
 hat_id = 228
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/monarchs_khan_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/monarchs_khan_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 29
+decal_id = 340
+wheels_id = 383
+boost_id = 37
+antenna_id = 0
+hat_id = 228
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 29
+decal_id = 340
+wheels_id = 383
+boost_id = 37
+antenna_id = 0
+hat_id = 228
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/monarchs_raja_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/monarchs_raja_appearance.cfg
@@ -1,21 +1,17 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 31
 decal_id = 357
 wheels_id = 383
 boost_id = 37
-antenna_id = 0
 hat_id = 228
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 31
 decal_id = 357
 wheels_id = 383
 boost_id = 37
-antenna_id = 0
 hat_id = 228
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/monarchs_raja_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/monarchs_raja_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 31
+decal_id = 357
+wheels_id = 383
+boost_id = 37
+antenna_id = 0
+hat_id = 228
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 31
+decal_id = 357
+wheels_id = 383
+boost_id = 37
+antenna_id = 0
+hat_id = 228
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/monarchs_rex_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/monarchs_rex_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 28
+decal_id = 331
+wheels_id = 383
+boost_id = 64
+antenna_id = 0
+hat_id = 228
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 28
+decal_id = 331
+wheels_id = 383
+boost_id = 64
+antenna_id = 0
+hat_id = 228
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/monarchs_rex_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/monarchs_rex_appearance.cfg
@@ -1,21 +1,17 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 28
 decal_id = 331
 wheels_id = 383
 boost_id = 64
-antenna_id = 0
 hat_id = 228
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 28
 decal_id = 331
 wheels_id = 383
 boost_id = 64
-antenna_id = 0
 hat_id = 228
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/monarchs_sultan_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/monarchs_sultan_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 24
+decal_id = 309
+wheels_id = 383
+boost_id = 37
+antenna_id = 0
+hat_id = 228
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 24
+decal_id = 309
+wheels_id = 383
+boost_id = 37
+antenna_id = 0
+hat_id = 228
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/monarchs_sultan_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/monarchs_sultan_appearance.cfg
@@ -1,21 +1,17 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 24
 decal_id = 309
 wheels_id = 383
 boost_id = 37
-antenna_id = 0
 hat_id = 228
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 24
 decal_id = 309
 wheels_id = 383
 boost_id = 37
-antenna_id = 0
 hat_id = 228
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/rebels_bandit_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/rebels_bandit_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 23
+decal_id = 304
+wheels_id = 364
+boost_id = 63
+antenna_id = 0
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 23
+decal_id = 304
+wheels_id = 364
+boost_id = 63
+antenna_id = 0
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/rebels_bandit_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/rebels_bandit_appearance.cfg
@@ -1,21 +1,15 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 23
 decal_id = 304
 wheels_id = 364
 boost_id = 63
-antenna_id = 0
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 23
 decal_id = 304
 wheels_id = 364
 boost_id = 63
-antenna_id = 0
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/rebels_dude_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/rebels_dude_appearance.cfg
@@ -1,21 +1,17 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 29
 decal_id = 337
 wheels_id = 364
 boost_id = 63
 antenna_id = 8
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 29
 decal_id = 337
 wheels_id = 364
 boost_id = 63
 antenna_id = 8
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/rebels_dude_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/rebels_dude_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 29
+decal_id = 337
+wheels_id = 364
+boost_id = 63
+antenna_id = 8
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 29
+decal_id = 337
+wheels_id = 364
+boost_id = 63
+antenna_id = 8
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/rebels_outlaw_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/rebels_outlaw_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 21
+decal_id = 0
+wheels_id = 364
+boost_id = 36
+antenna_id = 0
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 21
+decal_id = 0
+wheels_id = 364
+boost_id = 36
+antenna_id = 0
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/rebels_outlaw_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/rebels_outlaw_appearance.cfg
@@ -1,21 +1,15 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 21
 decal_id = 0
 wheels_id = 364
 boost_id = 36
-antenna_id = 0
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 21
 decal_id = 0
 wheels_id = 364
 boost_id = 36
-antenna_id = 0
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/rebels_poncho_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/rebels_poncho_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 25
+decal_id = 320
+wheels_id = 364
+boost_id = 63
+antenna_id = 0
+hat_id = 238
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 25
+decal_id = 320
+wheels_id = 364
+boost_id = 63
+antenna_id = 0
+hat_id = 238
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/rebels_poncho_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/rebels_poncho_appearance.cfg
@@ -1,21 +1,17 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 25
 decal_id = 320
 wheels_id = 364
 boost_id = 63
-antenna_id = 0
 hat_id = 238
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 25
 decal_id = 320
 wheels_id = 364
 boost_id = 63
-antenna_id = 0
 hat_id = 238
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/rovers_armstrong_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/rovers_armstrong_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 26
+decal_id = 326
+wheels_id = 373
+boost_id = 45
+antenna_id = 12
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 26
+decal_id = 326
+wheels_id = 373
+boost_id = 45
+antenna_id = 12
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/rovers_armstrong_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/rovers_armstrong_appearance.cfg
@@ -1,21 +1,17 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 26
 decal_id = 326
 wheels_id = 373
 boost_id = 45
 antenna_id = 12
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 26
 decal_id = 326
 wheels_id = 373
 boost_id = 45
 antenna_id = 12
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/rovers_buzz_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/rovers_buzz_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 22
+decal_id = 298
+wheels_id = 373
+boost_id = 49
+antenna_id = 206
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 22
+decal_id = 298
+wheels_id = 373
+boost_id = 49
+antenna_id = 206
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/rovers_buzz_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/rovers_buzz_appearance.cfg
@@ -1,21 +1,17 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 22
 decal_id = 298
 wheels_id = 373
 boost_id = 49
 antenna_id = 206
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 22
 decal_id = 298
 wheels_id = 373
 boost_id = 49
 antenna_id = 206
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/rovers_shepard_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/rovers_shepard_appearance.cfg
@@ -1,21 +1,17 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 24
 decal_id = 312
 wheels_id = 373
 boost_id = 45
 antenna_id = 17
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 24
 decal_id = 312
 wheels_id = 373
 boost_id = 45
 antenna_id = 17
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/rovers_shepard_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/rovers_shepard_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 24
+decal_id = 312
+wheels_id = 373
+boost_id = 45
+antenna_id = 17
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 24
+decal_id = 312
+wheels_id = 373
+boost_id = 45
+antenna_id = 17
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/rovers_yuri_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/rovers_yuri_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 28
+decal_id = 333
+wheels_id = 373
+boost_id = 52
+antenna_id = 186
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 28
+decal_id = 333
+wheels_id = 373
+boost_id = 52
+antenna_id = 186
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/rovers_yuri_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/rovers_yuri_appearance.cfg
@@ -1,21 +1,17 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 28
 decal_id = 333
 wheels_id = 373
 boost_id = 52
 antenna_id = 186
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 28
 decal_id = 333
 wheels_id = 373
 boost_id = 52
 antenna_id = 186
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/seekers_middy_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/seekers_middy_appearance.cfg
@@ -1,21 +1,17 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 23
 decal_id = 305
 wheels_id = 368
 boost_id = 33
-antenna_id = 0
 hat_id = 235
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 23
 decal_id = 305
 wheels_id = 368
 boost_id = 33
-antenna_id = 0
 hat_id = 235
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/seekers_middy_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/seekers_middy_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 23
+decal_id = 305
+wheels_id = 368
+boost_id = 33
+antenna_id = 0
+hat_id = 235
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 23
+decal_id = 305
+wheels_id = 368
+boost_id = 33
+antenna_id = 0
+hat_id = 235
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/seekers_saltie_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/seekers_saltie_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 28
+decal_id = 331
+wheels_id = 368
+boost_id = 69
+antenna_id = 0
+hat_id = 235
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 28
+decal_id = 331
+wheels_id = 368
+boost_id = 69
+antenna_id = 0
+hat_id = 235
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/seekers_saltie_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/seekers_saltie_appearance.cfg
@@ -1,21 +1,17 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 28
 decal_id = 331
 wheels_id = 368
 boost_id = 69
-antenna_id = 0
 hat_id = 235
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 28
 decal_id = 331
 wheels_id = 368
 boost_id = 69
-antenna_id = 0
 hat_id = 235
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/seekers_scout_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/seekers_scout_appearance.cfg
@@ -1,21 +1,17 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 29
 decal_id = 343
 wheels_id = 368
 boost_id = 69
-antenna_id = 0
 hat_id = 235
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 29
 decal_id = 343
 wheels_id = 368
 boost_id = 69
-antenna_id = 0
 hat_id = 235
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/seekers_scout_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/seekers_scout_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 29
+decal_id = 343
+wheels_id = 368
+boost_id = 69
+antenna_id = 0
+hat_id = 235
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 29
+decal_id = 343
+wheels_id = 368
+boost_id = 69
+antenna_id = 0
+hat_id = 235
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/seekers_swabbie_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/seekers_swabbie_appearance.cfg
@@ -1,21 +1,17 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 31
 decal_id = 353
 wheels_id = 368
 boost_id = 33
-antenna_id = 0
 hat_id = 235
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 31
 decal_id = 353
 wheels_id = 368
 boost_id = 33
-antenna_id = 0
 hat_id = 235
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/seekers_swabbie_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/seekers_swabbie_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 31
+decal_id = 353
+wheels_id = 368
+boost_id = 33
+antenna_id = 0
+hat_id = 235
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 31
+decal_id = 353
+wheels_id = 368
+boost_id = 33
+antenna_id = 0
+hat_id = 235
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/skyhawks_cougar_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/skyhawks_cougar_appearance.cfg
@@ -1,21 +1,17 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 22
 decal_id = 301
 wheels_id = 363
 boost_id = 58
-antenna_id = 0
 hat_id = 232
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 22
 decal_id = 301
 wheels_id = 363
 boost_id = 58
-antenna_id = 0
 hat_id = 232
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/skyhawks_cougar_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/skyhawks_cougar_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 22
+decal_id = 301
+wheels_id = 363
+boost_id = 58
+antenna_id = 0
+hat_id = 232
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 22
+decal_id = 301
+wheels_id = 363
+boost_id = 58
+antenna_id = 0
+hat_id = 232
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/skyhawks_goose_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/skyhawks_goose_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 22
+decal_id = 301
+wheels_id = 363
+boost_id = 53
+antenna_id = 0
+hat_id = 232
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 22
+decal_id = 301
+wheels_id = 363
+boost_id = 53
+antenna_id = 0
+hat_id = 232
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/skyhawks_goose_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/skyhawks_goose_appearance.cfg
@@ -1,21 +1,17 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 22
 decal_id = 301
 wheels_id = 363
 boost_id = 53
-antenna_id = 0
 hat_id = 232
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 22
 decal_id = 301
 wheels_id = 363
 boost_id = 53
-antenna_id = 0
 hat_id = 232
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/skyhawks_iceman_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/skyhawks_iceman_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 22
+decal_id = 301
+wheels_id = 363
+boost_id = 54
+antenna_id = 0
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 22
+decal_id = 301
+wheels_id = 363
+boost_id = 54
+antenna_id = 0
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/skyhawks_iceman_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/skyhawks_iceman_appearance.cfg
@@ -1,21 +1,15 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 22
 decal_id = 301
 wheels_id = 363
 boost_id = 54
-antenna_id = 0
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 22
 decal_id = 301
 wheels_id = 363
 boost_id = 54
-antenna_id = 0
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/skyhawks_maverick_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/skyhawks_maverick_appearance.cfg
@@ -1,21 +1,15 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 22
 decal_id = 301
 wheels_id = 363
 boost_id = 57
-antenna_id = 0
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 22
 decal_id = 301
 wheels_id = 363
 boost_id = 57
-antenna_id = 0
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/skyhawks_maverick_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/skyhawks_maverick_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 22
+decal_id = 301
+wheels_id = 363
+boost_id = 57
+antenna_id = 0
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 22
+decal_id = 301
+wheels_id = 363
+boost_id = 57
+antenna_id = 0
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_chipper_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_chipper_appearance.cfg
@@ -1,21 +1,15 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 21
 decal_id = 293
 wheels_id = 368
 boost_id = 63
-antenna_id = 0
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 21
 decal_id = 293
 wheels_id = 368
 boost_id = 63
-antenna_id = 0
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_chipper_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_chipper_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 21
+decal_id = 293
+wheels_id = 368
+boost_id = 63
+antenna_id = 0
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 21
+decal_id = 293
+wheels_id = 368
+boost_id = 63
+antenna_id = 0
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_heater_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_heater_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 30
+decal_id = 345
+wheels_id = 377
+boost_id = 41
+antenna_id = 0
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 30
+decal_id = 345
+wheels_id = 377
+boost_id = 41
+antenna_id = 0
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_heater_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_heater_appearance.cfg
@@ -1,21 +1,15 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 30
 decal_id = 345
 wheels_id = 377
 boost_id = 41
-antenna_id = 0
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 30
 decal_id = 345
 wheels_id = 377
 boost_id = 41
-antenna_id = 0
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_hollywood_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_hollywood_appearance.cfg
@@ -1,21 +1,17 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 22
 decal_id = 298
 wheels_id = 361
 boost_id = 51
 antenna_id = 3
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 22
 decal_id = 298
 wheels_id = 361
 boost_id = 51
 antenna_id = 3
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_hollywood_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_hollywood_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 22
+decal_id = 298
+wheels_id = 361
+boost_id = 51
+antenna_id = 3
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 22
+decal_id = 298
+wheels_id = 361
+boost_id = 51
+antenna_id = 3
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_jester_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_jester_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 26
+decal_id = 323
+wheels_id = 376
+boost_id = 34
+antenna_id = 0
+hat_id = 225
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 26
+decal_id = 323
+wheels_id = 376
+boost_id = 34
+antenna_id = 0
+hat_id = 225
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_jester_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_jester_appearance.cfg
@@ -1,21 +1,17 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 26
 decal_id = 323
 wheels_id = 376
 boost_id = 34
-antenna_id = 0
 hat_id = 225
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 26
 decal_id = 323
 wheels_id = 376
 boost_id = 34
-antenna_id = 0
 hat_id = 225
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_merlin_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_merlin_appearance.cfg
@@ -1,21 +1,17 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 24
 decal_id = 312
 wheels_id = 376
 boost_id = 62
-antenna_id = 0
 hat_id = 243
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 24
 decal_id = 312
 wheels_id = 376
 boost_id = 62
-antenna_id = 0
 hat_id = 243
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_merlin_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_merlin_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 24
+decal_id = 312
+wheels_id = 376
+boost_id = 62
+antenna_id = 0
+hat_id = 243
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 24
+decal_id = 312
+wheels_id = 376
+boost_id = 62
+antenna_id = 0
+hat_id = 243
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_slider_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_slider_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 29
+decal_id = 342
+wheels_id = 376
+boost_id = 63
+antenna_id = 0
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 29
+decal_id = 342
+wheels_id = 376
+boost_id = 63
+antenna_id = 0
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_slider_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_slider_appearance.cfg
@@ -1,21 +1,15 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 29
 decal_id = 342
 wheels_id = 376
 boost_id = 63
-antenna_id = 0
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 29
 decal_id = 342
 wheels_id = 376
 boost_id = 63
-antenna_id = 0
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_stinger_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_stinger_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 31
+decal_id = 352
+wheels_id = 376
+boost_id = 55
+antenna_id = 0
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 31
+decal_id = 352
+wheels_id = 376
+boost_id = 55
+antenna_id = 0
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_stinger_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_stinger_appearance.cfg
@@ -1,21 +1,15 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 31
 decal_id = 352
 wheels_id = 376
 boost_id = 55
-antenna_id = 0
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 31
 decal_id = 352
 wheels_id = 376
 boost_id = 55
-antenna_id = 0
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_sundown_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_sundown_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 22
+decal_id = 299
+wheels_id = 383
+boost_id = 36
+antenna_id = 0
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 22
+decal_id = 299
+wheels_id = 383
+boost_id = 36
+antenna_id = 0
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_sundown_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_sundown_appearance.cfg
@@ -1,21 +1,15 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 22
 decal_id = 299
 wheels_id = 383
 boost_id = 36
-antenna_id = 0
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 22
 decal_id = 299
 wheels_id = 383
 boost_id = 36
-antenna_id = 0
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_tex_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_tex_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 25
+decal_id = 319
+wheels_id = 360
+boost_id = 64
+antenna_id = 206
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 25
+decal_id = 319
+wheels_id = 360
+boost_id = 64
+antenna_id = 206
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_tex_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_tex_appearance.cfg
@@ -1,21 +1,17 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 25
 decal_id = 319
 wheels_id = 360
 boost_id = 64
 antenna_id = 206
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 25
 decal_id = 319
 wheels_id = 360
 boost_id = 64
 antenna_id = 206
-hat_id = 0
 

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_wolfman_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_wolfman_appearance.cfg
@@ -1,0 +1,21 @@
+[Bot Loadout]
+team_color_id = 35
+custom_color_id = 0
+car_id = 28
+decal_id = 330
+wheels_id = 376
+boost_id = 63
+antenna_id = 0
+hat_id = 0
+
+
+[Bot Loadout Orange]
+team_color_id = 33
+custom_color_id = 0
+car_id = 28
+decal_id = 330
+wheels_id = 376
+boost_id = 63
+antenna_id = 0
+hat_id = 0
+

--- a/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_wolfman_appearance.cfg
+++ b/src/main/python/rlbot/matchconfig/psyonix_presets/teammates_wolfman_appearance.cfg
@@ -1,21 +1,15 @@
 [Bot Loadout]
 team_color_id = 35
-custom_color_id = 0
 car_id = 28
 decal_id = 330
 wheels_id = 376
 boost_id = 63
-antenna_id = 0
-hat_id = 0
 
 
 [Bot Loadout Orange]
 team_color_id = 33
-custom_color_id = 0
 car_id = 28
 decal_id = 330
 wheels_id = 376
 boost_id = 63
-antenna_id = 0
-hat_id = 0
 

--- a/src/main/python/rlbot/parsing/agent_config_parser.py
+++ b/src/main/python/rlbot/parsing/agent_config_parser.py
@@ -84,19 +84,19 @@ def create_looks_configurations() -> ConfigObject:
 
 def create_loadout() -> ConfigHeader:
     header = ConfigHeader()
-    header.add_value('team_color_id', int, default=60, description='Primary Color selection')
+    header.add_value('team_color_id', int, default=0, description='Primary Color selection')
     header.add_value('custom_color_id', int, default=0, description='Secondary Color selection')
-    header.add_value('car_id', int, default=23, description='Car type (Octane, Merc, etc)')
+    header.add_value('car_id', int, default=0, description='Car type (Octane, Merc, etc)')
     header.add_value('decal_id', int, default=0, description='Type of decal')
-    header.add_value('wheels_id', int, default=1565, description='Wheel selection')
-    header.add_value('boost_id', int, default=35, description='Boost selection')
+    header.add_value('wheels_id', int, default=0, description='Wheel selection')
+    header.add_value('boost_id', int, default=0, description='Boost selection')
     header.add_value('antenna_id', int, default=0, description='Antenna Selection')
     header.add_value('hat_id', int, default=0, description='Hat Selection')
-    header.add_value('paint_finish_id', int, default=1681, description='Paint Type (for first color)')
-    header.add_value('custom_finish_id', int, default=1681, description='Paint Type (for secondary color)')
+    header.add_value('paint_finish_id', int, default=0, description='Paint Type (for first color)')
+    header.add_value('custom_finish_id', int, default=0, description='Paint Type (for secondary color)')
     header.add_value('engine_audio_id', int, default=0, description='Engine Audio Selection')
-    header.add_value('trails_id', int, default=3220, description='Car trail Selection')
-    header.add_value('goal_explosion_id', int, default=3018, description='Goal Explosion Selection')
+    header.add_value('trails_id', int, default=0, description='Car trail Selection')
+    header.add_value('goal_explosion_id', int, default=0, description='Goal Explosion Selection')
     header.add_value('primary_color_lookup', str, default=None,
                      description='Finds the closest primary color swatch based on the provided RGB value '
                                  'like [34, 255, 60]')
@@ -136,8 +136,10 @@ def parse_bot_loadout(player_configuration, bot_config, loadout_header):
     player_configuration.engine_audio_id = bot_config.getint(loadout_header, 'engine_audio_id')
     player_configuration.trails_id = bot_config.getint(loadout_header, 'trails_id')
     player_configuration.goal_explosion_id = bot_config.getint(loadout_header, 'goal_explosion_id')
-    player_configuration.primary_color_lookup = parse_color_string(bot_config.get(loadout_header, 'primary_color_lookup'))
-    player_configuration.secondary_color_lookup = parse_color_string(bot_config.get(loadout_header, 'secondary_color_lookup'))
+    player_configuration.primary_color_lookup = parse_color_string(
+        bot_config.get(loadout_header, 'primary_color_lookup'))
+    player_configuration.secondary_color_lookup = parse_color_string(
+        bot_config.get(loadout_header, 'secondary_color_lookup'))
 
 
 def parse_color_string(color_lookup_string):


### PR DESCRIPTION
This allows Psyonix bot types to get their original names and appearances.This also keeps the distinction between different skill levels by Inserting "Pro" or "Rookie" Before the name preset (for example, Hound with a skill level of 0.0 will become "Rookie Hound")
I've tested it on RLBotGUI and the old GUI, and it seems to work fine.