### PR TITLE
Making the Java bot manager handle lockstep better.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ dependencies {
 }
 
 project.setGroup('org.rlbot.commons')
-project.setVersion('2.0.0')
+project.setVersion('2.0.1')
 
 sourceSets {
     main {


### PR DESCRIPTION
Before this change, java lockstep is quite stuttery because the bot manager would often wait a bit hoping for a fresh packet when the game was paused.