### PR TITLE
Loadout generator feature.

### DIFF
--- a/src/main/python/rlbot/agents/base_agent.py
+++ b/src/main/python/rlbot/agents/base_agent.py
@@ -18,6 +18,7 @@ BOT_CONFIG_MODULE_HEADER = 'Locations'
 BOT_CONFIG_AGENT_HEADER = 'Bot Parameters'
 BOT_CONFIG_DETAILS_HEADER = 'Details'
 PYTHON_FILE_KEY = 'python_file'
+LOADOUT_GENERATOR_FILE_KEY = 'loadout_generator'
 LOGO_FILE_KEY = 'logo_file'
 LOOKS_CONFIG_KEY = 'looks_config'
 BOT_NAME_KEY = "name"
@@ -293,6 +294,8 @@ class BaseAgent:
         location_config = config.add_header_name(BOT_CONFIG_MODULE_HEADER)
         location_config.add_value(LOOKS_CONFIG_KEY, str,
                                   description='Path to loadout config from runner')
+        location_config.add_value(LOADOUT_GENERATOR_FILE_KEY, str,
+                                  description="A file that provide dynamic bot loadouts (optional).")
         location_config.add_value(PYTHON_FILE_KEY, str,
                                   description="Bot's python file.\nOnly need this if RLBot controlled")
         location_config.add_value(BOT_NAME_KEY, str, default='nameless',

--- a/src/main/python/rlbot/agents/base_loadout_generator.py
+++ b/src/main/python/rlbot/agents/base_loadout_generator.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+from rlbot.matchconfig.loadout_config import LoadoutConfig
+from rlbot.parsing.agent_config_parser import create_looks_configurations, load_bot_appearance
+
+
+class BaseLoadoutGenerator:
+
+    def __init__(self, base_directory: Path):
+        self.base_directory = base_directory
+
+    def generate_loadout(self, player_index: int, team: int) -> LoadoutConfig:
+        raise NotImplementedError("You need to override the generate_loadout function!")
+
+    def load_cfg_file(self, file_path: Path, team: int) -> LoadoutConfig:
+        file = self.base_directory / Path(file_path)
+        config_object = create_looks_configurations().parse_file(file)
+        return load_bot_appearance(config_object, team)

--- a/src/main/python/rlbot/matchconfig/conversions.py
+++ b/src/main/python/rlbot/matchconfig/conversions.py
@@ -47,9 +47,8 @@ def parse_match_config(config_parser: ConfigObject, config_location, config_bund
 
         config_bundle = config_bundles[i]
 
-        if i not in looks_config_overrides:
-            looks_config_object = config_bundle.get_looks_config()
-        else:
+        looks_config_object = None
+        if i in looks_config_overrides:
             looks_config_object = looks_config_overrides[i]
 
         player_config = _load_bot_config(i, config_bundle, looks_config_object, config_parser, human_index_tracker)
@@ -127,7 +126,11 @@ def _load_bot_config(index, config_bundle: BotConfigBundle,
     # Setting up the bots name
     bot_configuration.name = config_bundle.name
 
-    loadout_config = load_bot_appearance(looks_config_object, team_num)
+    if looks_config_object:
+        loadout_config = load_bot_appearance(looks_config_object, team_num)
+    else:
+        loadout_config = config_bundle.generate_loadout_config(index, team_num)
+
     bot_configuration.loadout_config = loadout_config
 
     return bot_configuration

--- a/src/main/python/rlbot/parsing/bot_config_bundle.py
+++ b/src/main/python/rlbot/parsing/bot_config_bundle.py
@@ -40,7 +40,7 @@ class BotConfigBundle:
     def get_absolute_path(self, header, key):
         path = self.base_agent_config.get(header, key)
         if path is None:
-            raise configparser.NoSectionError(f"Could not find {header}: {key} in the provided configuration!")
+            return None
         if os.path.isabs(path):
             return path
         if self.config_directory is None:

--- a/src/main/python/rlbot/setup_manager.py
+++ b/src/main/python/rlbot/setup_manager.py
@@ -261,8 +261,7 @@ class SetupManager:
         for index, bot in enumerate(match_config.player_configs):
             self.bot_bundles.append(bundles[index])
             if bot.loadout_config is None and bundles[index]:
-                looks_config = bundles[index].get_looks_config()
-                bot.loadout_config = load_bot_appearance(looks_config, bot.team)
+                bot.loadout_config = bundles[index].generate_loadout_config(index, bot.team)
 
         if match_config.extension_config is not None and match_config.extension_config.python_file_path is not None:
             self.load_extension(match_config.extension_config.python_file_path)

--- a/src/main/python/rlbot/version.py
+++ b/src/main/python/rlbot/version.py
@@ -4,9 +4,14 @@
 # 3) we can import it into your module module
 # https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
 
-__version__ = '1.38.1'
+__version__ = '1.39.0'
 
 release_notes = {
+    '1.39.0': """
+    You can now generate a fresh loadout for your bot every match using a python script!
+    Try setting different colors based on your player index, or a randomized hat.
+    Learn how at https://github.com/RLBot/RLBot/wiki/Bot-Customization#loadout-generator
+    """,
     '1.38.1': """
     Ball prediction is now computed at 120Hz instead of 60Hz!
     

--- a/src/test/python/agents/atba/atba.cfg
+++ b/src/test/python/agents/atba/atba.cfg
@@ -4,6 +4,9 @@ looks_config = ./atba_looks.cfg
 # Bot's python file.
 # Only need this if RLBot controlled
 python_file = atba.py
+
+loadout_generator = atba_loadout.py
+
 # The name that will be displayed in game
 name = AlwaysTowardsBallAgent
 maximum_tick_rate_preference = 120

--- a/src/test/python/agents/atba/atba_loadout.py
+++ b/src/test/python/agents/atba/atba_loadout.py
@@ -1,0 +1,20 @@
+import random
+from pathlib import Path
+
+from rlbot.agents.base_loadout_generator import BaseLoadoutGenerator
+from rlbot.matchconfig.loadout_config import LoadoutConfig
+
+
+class AtbaLoadoutGenerator(BaseLoadoutGenerator):
+    def generate_loadout(self, player_index: int, team: int) -> LoadoutConfig:
+
+        # Start with a loadout based on the cfg file in the same directory as this generator
+        loadout = self.load_cfg_file(Path('atba_looks.cfg'), team)
+
+        if player_index == 0:
+            loadout.antenna_id = 287
+
+        loadout.team_color_id = player_index
+        loadout.paint_config.wheels_paint_id = random.choice([1, 2, 4, 5])
+
+        return loadout


### PR DESCRIPTION
Gives the ability to generate your bot's loadout with a python script. This lets you choose different loadouts based on player index, randomize parts of your loadout, etc. The script is executed at the beginning of every match.

To use this feature, put a line like `loadout_generator = loadout_generator_example.py` in your bot cfg file, in the [Locations] section. Then create a python file like this:
```python
import random
from pathlib import Path

from rlbot.agents.base_loadout_generator import BaseLoadoutGenerator
from rlbot.matchconfig.loadout_config import LoadoutConfig


class SampleLoadoutGenerator(BaseLoadoutGenerator):
    def generate_loadout(self, player_index: int, team: int) -> LoadoutConfig:

        # You could start with a loadout based on a cfg file in the same directory as this generator
        loadout = self.load_cfg_file(Path('appearance'), team)

        # Or you could start from scratch like this
        # loadout = LoadoutConfig()

        if player_index == 0:
            loadout.antenna_id = 287  # use a Psyonix flag if you're the first player

        loadout.team_color_id = player_index  # Different primary color depending on player index
        loadout.paint_config.wheels_paint_id = random.choice([1, 2, 4, 5])  # Random wheel color

        return loadout
```