### PR TITLE
Hivemind support for Java (and Kotlin)

### DIFF
--- a/src/main/java/rlbot/Hivemind.java
+++ b/src/main/java/rlbot/Hivemind.java
@@ -8,11 +8,12 @@ import java.util.Set;
 public interface Hivemind {
 
     /**
-     * Hivemind logic goes here. Returns a mapping from drone indexes to ControllerStates based on the information
-     * given in the GameTickPacket.
+     * <p>Hivemind logic goes here. Returns a mapping from drone indexes to ControllerStates based on the information
+     * given in the GameTickPacket. Only return ControllerStates for the indexes included in the droneIndexes
+     * argument.</p>
      *
-     * droneIndexes might change during the game if drones join or leave. Therefore you should make sure to check
-     * whether the indexes you control are changed. For instance do:
+     * <p>droneIndexes might change during the game if drones join or leave. Therefore you should make sure to check
+     * whether the indexes you control are changed. For instance do:</p>
      * <pre>
      * {@code
      * if (oldIndexes.equals(droneIndexes)) {

--- a/src/main/java/rlbot/Hivemind.java
+++ b/src/main/java/rlbot/Hivemind.java
@@ -8,23 +8,23 @@ import java.util.Set;
 public interface Hivemind {
 
     /**
-     * <p>Hivemind logic goes here. Returns a mapping from drone indexes to ControllerStates based on the information
-     * given in the GameTickPacket. Only return ControllerStates for the indexes included in the droneIndexes
+     * <p>Hivemind logic goes here. Returns a mapping from drone indices to ControllerStates based on the information
+     * given in the GameTickPacket. Only return ControllerStates for the indices included in the droneIndices
      * argument.</p>
      *
-     * <p>droneIndexes might change during the game if drones join or leave. Therefore you should make sure to check
-     * whether the indexes you control are changed. For instance do:</p>
+     * <p>droneIndices might change during the game if drones join or leave. Therefore you should make sure to check
+     * whether the indices you control are changed. For instance do:</p>
      * <pre>
      * {@code
-     * if (oldIndexes.equals(droneIndexes)) {
+     * if (oldIndices.equals(droneIndices)) {
      *     // Hive changed
      * }
-     * oldIndexes = droneIndexes;
+     * oldIndices = droneIndices;
      * }
      * </pre>
-     * where oldIndexes are a field in your hivemind.
+     * where oldIndices are a field in your hivemind.
      */
-    Map<Integer, ControllerState> processInput(Set<Integer> droneIndexes, GameTickPacket request);
+    Map<Integer, ControllerState> processInput(Set<Integer> droneIndices, GameTickPacket request);
 
     /**
      * Shuts down the hive and close any resources it's using.

--- a/src/main/java/rlbot/Hivemind.java
+++ b/src/main/java/rlbot/Hivemind.java
@@ -1,0 +1,32 @@
+package rlbot;
+
+import rlbot.flat.GameTickPacket;
+
+import java.util.Map;
+import java.util.Set;
+
+public interface Hivemind {
+
+    /**
+     * Hivemind logic goes here. Returns a mapping from drone indexes to ControllerStates based on the information
+     * given in the GameTickPacket.
+     *
+     * droneIndexes might change during the game if drones join or leave. Therefore you should make sure to check
+     * whether the indexes you control are changed. For instance do:
+     * <pre>
+     * {@code
+     * if (oldIndexes.equals(droneIndexes)) {
+     *     // Hive changed
+     * }
+     * oldIndexes = droneIndexes;
+     * }
+     * </pre>
+     * where oldIndexes are a field in your hivemind.
+     */
+    Map<Integer, ControllerState> processInput(Set<Integer> droneIndexes, GameTickPacket request);
+
+    /**
+     * Shuts down the hive and close any resources it's using.
+     */
+    void retire();
+}

--- a/src/main/java/rlbot/manager/BaseBotManager.java
+++ b/src/main/java/rlbot/manager/BaseBotManager.java
@@ -7,6 +7,10 @@ import rlbot.flat.GameTickPacket;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 
+/**
+ * This class keeps track of all the bots, runs the main logic loops, and retrieves the
+ * game data on behalf of the bots.
+ */
 abstract public class BaseBotManager implements IBotManager {
 
     private final AtomicInteger refreshRate = new AtomicInteger(60);

--- a/src/main/java/rlbot/manager/BaseBotManager.java
+++ b/src/main/java/rlbot/manager/BaseBotManager.java
@@ -1,0 +1,119 @@
+package rlbot.manager;
+
+import rlbot.cppinterop.RLBotDll;
+import rlbot.cppinterop.RLBotInterfaceException;
+import rlbot.flat.GameTickPacket;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+abstract public class BaseBotManager implements IBotManager {
+
+    private final AtomicInteger refreshRate = new AtomicInteger(60);
+
+    protected boolean keepRunning;
+    protected final Object dinnerBell = new Object();
+    protected GameTickPacket latestPacket;
+
+    @Override
+    public void ensureStarted() {
+        if (keepRunning) {
+            return; // Already started
+        }
+
+        keepRunning = true;
+        Thread looper = new Thread(this::doLoop);
+        looper.start();
+    }
+
+    private void doLoop() {
+        // Minimum call rate when paused.
+        final long MAX_AGENT_CALL_PERIOD = 1000 / 30;
+
+        long lastCallRealTime = System.currentTimeMillis();
+        float lastTickGameTime = 0;
+        boolean usingLockstep = false;
+
+        try {
+            usingLockstep = RLBotDll.getMatchSettings().enableLockstep();
+        } catch (final RLBotInterfaceException e) {
+            e.printStackTrace();
+        }
+
+        try {
+            latestPacket = RLBotDll.getFlatbufferPacket();
+            lastTickGameTime = latestPacket.gameInfo().secondsElapsed();
+        } catch (RLBotInterfaceException e) {
+            e.printStackTrace();
+        }
+
+        // Set the initial value so that as urgency flips up and down, the variation will be centered over
+        // the threshold (0 urgency) and have minimal likelihood of drifting away and skipping a frame
+        float frameUrgency = -0.5f / this.refreshRate.get();
+
+        while (keepRunning) {
+            // Python version: https://github.com/RLBot/RLBot/blob/master/src/main/python/rlbot/botmanager/bot_manager.py#L194-L212
+            final int refreshRate = this.refreshRate.get();
+            try {
+                // Retrieve latest packet
+                if (usingLockstep) {
+                    latestPacket = RLBotDll.getCurrentFlatbufferPacket();
+                } else {
+                    latestPacket = RLBotDll.getFlatbufferPacket();
+                }
+
+                // Run the bot only if gameInfo has updated
+                final float tickGameTime = latestPacket.gameInfo().secondsElapsed();
+                final long now = System.currentTimeMillis();
+                final boolean shouldCallWhilePaused = now - lastCallRealTime >= MAX_AGENT_CALL_PERIOD;
+
+                // Urgency increases every frame, but don't let it build up a large backlog
+                frameUrgency += tickGameTime - lastTickGameTime;
+                frameUrgency = clamp(frameUrgency, -1f / refreshRate, 1f / refreshRate);
+
+                if((tickGameTime != lastTickGameTime || shouldCallWhilePaused) && frameUrgency >= 0 || usingLockstep){
+                    lastCallRealTime = now;
+                    // Urgency decreases when a tick is processed.
+                    frameUrgency -= 1f / refreshRate;
+                    synchronized (dinnerBell) {
+                        dinnerBell.notifyAll();
+                    }
+                }
+
+                lastTickGameTime = tickGameTime;
+
+                if (usingLockstep) {
+                    try {
+                        Thread.sleep(1000 / refreshRate);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    @Override
+    public void shutDown() {
+        keepRunning = false;
+    }
+
+    /**
+     * Sets the maximum amount of packets your bot will receive per second
+     */
+    @Override
+    public void setRefreshRate(int refreshRate) {
+        // Cap the refresh between 30hz and 120hz
+        this.refreshRate.set(clamp(refreshRate, 30, 120));
+    }
+
+    private static int clamp(int value, int min, int max) {
+        return Math.max(min, Math.min(value, max));
+    }
+
+    private static float clamp(float value, float min, float max) {
+        return Math.max(min, Math.min(value, max));
+    }
+}

--- a/src/main/java/rlbot/manager/BotManager.java
+++ b/src/main/java/rlbot/manager/BotManager.java
@@ -16,11 +16,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 /**
- * This class is a BotManager for single bots.
+ * This class is a default BotManager for bots. It runs the main logic loops, and retrieves the
+ *  game data on behalf of the bots.
  */
 public class BotManager extends BaseBotManager {
 
-    protected final Map<Integer, BotProcess> botProcesses = new ConcurrentHashMap<>();
+    private final Map<Integer, BotProcess> botProcesses = new ConcurrentHashMap<>();
 
     public void ensureBotRegistered(final int index, final int team, final Supplier<Bot> botSupplier) {
         if (botProcesses.containsKey(index)) {

--- a/src/main/java/rlbot/manager/BotManager.java
+++ b/src/main/java/rlbot/manager/BotManager.java
@@ -16,8 +16,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 /**
- * This class keeps track of all the bots, runs the main logic loops, and retrieves the
- * game data on behalf of the bots.
+ * This class is a BotManager for single bots.
  */
 public class BotManager extends BaseBotManager {
 

--- a/src/main/java/rlbot/manager/BotManager.java
+++ b/src/main/java/rlbot/manager/BotManager.java
@@ -18,17 +18,18 @@ import java.util.function.Supplier;
  * This class keeps track of all the bots, runs the main logic loops, and retrieves the
  * game data on behalf of the bots.
  */
-public class BotManager {
+public class BotManager implements IBotManager {
 
-    private final Map<Integer, BotProcess> botProcesses = new ConcurrentHashMap<>();
+    protected final Map<Integer, BotProcess> botProcesses = new ConcurrentHashMap<>();
 
-    private boolean keepRunning;
+    protected boolean keepRunning;
 
-    private final Object dinnerBell = new Object();
-    private GameTickPacket latestPacket;
-    private AtomicInteger refreshRate = new AtomicInteger(60);
+    protected final Object dinnerBell = new Object();
+    protected GameTickPacket latestPacket;
+    protected AtomicInteger refreshRate = new AtomicInteger(60);
 
-    public void ensureBotRegistered(final int index, final Supplier<Bot> botSupplier) {
+    @Override
+    public void ensureBotRegistered(final int index, final int team, final Supplier<Bot> botSupplier) {
         if (botProcesses.containsKey(index)) {
             return;
         }
@@ -68,6 +69,7 @@ public class BotManager {
         }
     }
 
+    @Override
     public void ensureStarted() {
         if (keepRunning) {
             return; // Already started
@@ -84,6 +86,7 @@ public class BotManager {
      *
      * This may be useful for driving a basic status display.
      */
+    @Override
     public Set<Integer> getRunningBotIndices() {
         return botProcesses.keySet();
     }
@@ -157,11 +160,13 @@ public class BotManager {
         }
     }
 
+    @Override
     public void shutDown() {
         keepRunning = false;
         botProcesses.clear();
     }
 
+    @Override
     public void retireBot(int index) {
         BotProcess process = botProcesses.get(index);
         if (process != null) {
@@ -174,7 +179,8 @@ public class BotManager {
     /**
      * Sets the maximum amount of packets your bot will receive per second
      */
-    public void setRefreshRate(int refreshRate){
+    @Override
+    public void setRefreshRate(int refreshRate) {
         // Cap the refresh between 30hz and 120hz
         this.refreshRate.set(clamp(refreshRate, 30, 120));
     }

--- a/src/main/java/rlbot/manager/HivemindManager.java
+++ b/src/main/java/rlbot/manager/HivemindManager.java
@@ -7,11 +7,10 @@ import rlbot.cppinterop.RLBotDll;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
-public class HivemindManager extends BotManager {
+public class HivemindManager extends BaseBotManager {
 
     private final HivemindProcess[] hivemindProcesses = new HivemindProcess[2];
 
@@ -43,6 +42,7 @@ public class HivemindManager extends BotManager {
                 if (latestPacket != null) {
 
                     Set<Integer> droneIndexes = hivemindProcesses[team].getDroneIndexes();
+                    if (droneIndexes.isEmpty()) continue;
                     Map<Integer, ControllerState> hivemindOutput = hivemind.processInput(droneIndexes, latestPacket);
 
                     if (droneIndexes.size() > hivemindOutput.size())
@@ -69,6 +69,7 @@ public class HivemindManager extends BotManager {
         }
     }
 
+    @Override
     public Set<Integer> getRunningBotIndices() {
         Set<Integer> blueIndexes = hivemindProcesses[0].getDroneIndexes();
         Set<Integer> orangeIndexes = hivemindProcesses[1].getDroneIndexes();
@@ -78,6 +79,7 @@ public class HivemindManager extends BotManager {
         return allIndexes;
     }
 
+    @Override
     public void retireBot(int index) {
         hivemindProcesses[0].retireDrone(index);
         hivemindProcesses[1].retireDrone(index);

--- a/src/main/java/rlbot/manager/HivemindManager.java
+++ b/src/main/java/rlbot/manager/HivemindManager.java
@@ -11,10 +11,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
 /**
- * This class is a BotManager for the hiveminds.
+ * This class is a BotManager for hiveminds. It runs the main logic loops and retrieves GameTickPackets for
+ * the hiveminds.
  */
 public class HivemindManager extends BaseBotManager {
 
+    // There are only every two hiveminds of this bot, once for each team
     private final HivemindProcess[] hivemindProcesses = new HivemindProcess[2];
     private final Function<Integer, Hivemind> hivemindSupplier;
 
@@ -23,7 +25,7 @@ public class HivemindManager extends BaseBotManager {
     }
 
     public void ensureBotRegistered(int index, int team) {
-        if (hivemindProcesses[team] == null || !hivemindProcesses[team].runFlag.get()) {
+        if (hivemindProcesses[team] == null || !hivemindProcesses[team].isRunning()) {
             // Start a new instance of the hivemind
             Hivemind hivemind = hivemindSupplier.apply(team);
             final AtomicBoolean runFlag = new AtomicBoolean(true);
@@ -77,8 +79,8 @@ public class HivemindManager extends BaseBotManager {
     @Override
     public Set<Integer> getRunningBotIndices() {
         HashSet<Integer> allIndices = new HashSet<>();
-        if (hivemindProcesses[0] != null && hivemindProcesses[0].runFlag.get()) allIndices.addAll(hivemindProcesses[0].getDroneIndices());
-        if (hivemindProcesses[1] != null && hivemindProcesses[1].runFlag.get()) allIndices.addAll(hivemindProcesses[1].getDroneIndices());
+        if (hivemindProcesses[0] != null && hivemindProcesses[0].isRunning()) allIndices.addAll(hivemindProcesses[0].getDroneIndices());
+        if (hivemindProcesses[1] != null && hivemindProcesses[1].isRunning()) allIndices.addAll(hivemindProcesses[1].getDroneIndices());
         return allIndices;
     }
 
@@ -89,7 +91,7 @@ public class HivemindManager extends BaseBotManager {
      * This may be useful for driving a basic status display.
      */
     public Set<Integer> getRunningBotIndicesForBlue() {
-        if (hivemindProcesses[0] != null && hivemindProcesses[0].runFlag.get()) {
+        if (hivemindProcesses[0] != null && hivemindProcesses[0].isRunning()) {
             return hivemindProcesses[0].getDroneIndices();
         }
         return new HashSet<>();
@@ -102,7 +104,7 @@ public class HivemindManager extends BaseBotManager {
      * This may be useful for driving a basic status display.
      */
     public Set<Integer> getRunningBotIndicesForOrange() {
-        if (hivemindProcesses[1] != null && hivemindProcesses[1].runFlag.get()) {
+        if (hivemindProcesses[1] != null && hivemindProcesses[1].isRunning()) {
             return hivemindProcesses[1].getDroneIndices();
         }
         return new HashSet<>();

--- a/src/main/java/rlbot/manager/HivemindManager.java
+++ b/src/main/java/rlbot/manager/HivemindManager.java
@@ -10,6 +10,9 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
+/**
+ * This class is a BotManager for the hiveminds.
+ */
 public class HivemindManager extends BaseBotManager {
 
     private final HivemindProcess[] hivemindProcesses = new HivemindProcess[2];

--- a/src/main/java/rlbot/manager/HivemindManager.java
+++ b/src/main/java/rlbot/manager/HivemindManager.java
@@ -46,17 +46,17 @@ public class HivemindManager extends BaseBotManager {
                 }
                 if (latestPacket != null) {
 
-                    Set<Integer> droneIndexes = hivemindProcesses[team].getDroneIndexes();
-                    if (droneIndexes.isEmpty()) continue;
-                    Map<Integer, ControllerState> hivemindOutput = hivemind.processInput(droneIndexes, latestPacket);
+                    Set<Integer> droneIndices = hivemindProcesses[team].getDroneIndices();
+                    if (droneIndices.isEmpty()) continue;
+                    Map<Integer, ControllerState> hivemindOutput = hivemind.processInput(droneIndices, latestPacket);
 
-                    if (droneIndexes.size() > hivemindOutput.size())
+                    if (droneIndices.size() > hivemindOutput.size())
                         System.out.println("Not enough outputs were given.");
-                    else if (droneIndexes.size() < hivemindOutput.size())
+                    else if (droneIndices.size() < hivemindOutput.size())
                         System.out.println("Too many inputs were given.");
 
                     for (Integer index : hivemindOutput.keySet()) {
-                        if (!droneIndexes.contains(index)) {
+                        if (!droneIndices.contains(index)) {
                             System.out.println("Tried to send output for a bot index (" + index + ") that is not part of the hivemind");
                             continue;
                         }
@@ -76,10 +76,10 @@ public class HivemindManager extends BaseBotManager {
 
     @Override
     public Set<Integer> getRunningBotIndices() {
-        HashSet<Integer> allIndexes = new HashSet<>();
-        if (hivemindProcesses[0] != null && hivemindProcesses[0].runFlag.get()) allIndexes.addAll(hivemindProcesses[0].getDroneIndexes());
-        if (hivemindProcesses[1] != null && hivemindProcesses[1].runFlag.get()) allIndexes.addAll(hivemindProcesses[1].getDroneIndexes());
-        return allIndexes;
+        HashSet<Integer> allIndices = new HashSet<>();
+        if (hivemindProcesses[0] != null && hivemindProcesses[0].runFlag.get()) allIndices.addAll(hivemindProcesses[0].getDroneIndices());
+        if (hivemindProcesses[1] != null && hivemindProcesses[1].runFlag.get()) allIndices.addAll(hivemindProcesses[1].getDroneIndices());
+        return allIndices;
     }
 
     /**
@@ -90,7 +90,7 @@ public class HivemindManager extends BaseBotManager {
      */
     public Set<Integer> getRunningBotIndicesForBlue() {
         if (hivemindProcesses[0] != null && hivemindProcesses[0].runFlag.get()) {
-            return hivemindProcesses[0].getDroneIndexes();
+            return hivemindProcesses[0].getDroneIndices();
         }
         return new HashSet<>();
     }
@@ -103,7 +103,7 @@ public class HivemindManager extends BaseBotManager {
      */
     public Set<Integer> getRunningBotIndicesForOrange() {
         if (hivemindProcesses[1] != null && hivemindProcesses[1].runFlag.get()) {
-            return hivemindProcesses[1].getDroneIndexes();
+            return hivemindProcesses[1].getDroneIndices();
         }
         return new HashSet<>();
     }

--- a/src/main/java/rlbot/manager/HivemindManager.java
+++ b/src/main/java/rlbot/manager/HivemindManager.java
@@ -16,7 +16,7 @@ import java.util.function.Function;
  */
 public class HivemindManager extends BaseBotManager {
 
-    // There are only ever two hiveminds of this bot, once for each team
+    // There are only ever two hiveminds of this bot, one for each team.
     private final HivemindProcess[] hivemindProcesses = new HivemindProcess[2];
     private final Function<Integer, Hivemind> hivemindSupplier;
 

--- a/src/main/java/rlbot/manager/HivemindManager.java
+++ b/src/main/java/rlbot/manager/HivemindManager.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -17,11 +18,11 @@ public class HivemindManager extends BaseBotManager {
 
     private final HivemindProcess[] hivemindProcesses = new HivemindProcess[2];
 
-    public HivemindManager(Supplier<Hivemind> hivemindSupplier) {
+    public HivemindManager(Function<Integer, Hivemind> hivemindSupplier) {
         // Setup two hivemind processes. One for each team
         for (int i = 0; i < 2; i++) {
             final int team = i;
-            Hivemind hivemind = hivemindSupplier.get();
+            Hivemind hivemind = hivemindSupplier.apply(team);
             final AtomicBoolean runFlag = new AtomicBoolean(true);
             Thread hiveTread = new Thread(() -> doHiveLoop(hivemind, team, runFlag));
             hiveTread.start();

--- a/src/main/java/rlbot/manager/HivemindManager.java
+++ b/src/main/java/rlbot/manager/HivemindManager.java
@@ -16,7 +16,7 @@ import java.util.function.Function;
  */
 public class HivemindManager extends BaseBotManager {
 
-    // There are only every two hiveminds of this bot, once for each team
+    // There are only ever two hiveminds of this bot, once for each team
     private final HivemindProcess[] hivemindProcesses = new HivemindProcess[2];
     private final Function<Integer, Hivemind> hivemindSupplier;
 

--- a/src/main/java/rlbot/manager/HivemindManager.java
+++ b/src/main/java/rlbot/manager/HivemindManager.java
@@ -1,0 +1,89 @@
+package rlbot.manager;
+
+import rlbot.ControllerState;
+import rlbot.Hivemind;
+import rlbot.cppinterop.RLBotDll;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
+public class HivemindManager extends BotManager {
+
+    private final HivemindProcess[] hivemindProcesses = new HivemindProcess[2];
+
+    public HivemindManager(Supplier<Hivemind> hivemindSupplier) {
+        // Setup two hivemind processes. One for each team
+        for (int i = 0; i < 2; i++) {
+            final int team = i;
+            Hivemind hivemind = hivemindSupplier.get();
+            final AtomicBoolean runFlag = new AtomicBoolean(true);
+            Thread hiveTread = new Thread(() -> doHiveLoop(hivemind, team, runFlag));
+            hiveTread.start();
+            hivemindProcesses[i] = new HivemindProcess(hiveTread, runFlag);
+        }
+    }
+
+    public void ensureBotRegistered(int index, int team) {
+        hivemindProcesses[team].registerDrone(index);
+    }
+
+    private void doHiveLoop(Hivemind hivemind, final int team, final AtomicBoolean runFlag) {
+
+        try {
+            while (keepRunning && runFlag.get()) {
+
+                synchronized (dinnerBell) {
+                    // Wait for the main thread to indicate that we have new game tick data.
+                    dinnerBell.wait(1000);
+                }
+                if (latestPacket != null) {
+
+                    Set<Integer> droneIndexes = hivemindProcesses[team].getDroneIndexes();
+                    Map<Integer, ControllerState> hivemindOutput = hivemind.processInput(droneIndexes, latestPacket);
+
+                    if (droneIndexes.size() > hivemindOutput.size())
+                        System.out.println("Not enough outputs were given.");
+                    else if (droneIndexes.size() < hivemindOutput.size())
+                        System.out.println("Too many inputs were given.");
+
+                    for (Integer index : hivemindOutput.keySet()) {
+                        if (!droneIndexes.contains(index)) {
+                            System.out.println("Tried to send output for a bot index (" + index + ") that is not part of the hivemind");
+                            continue;
+                        }
+                        ControllerState output = hivemindOutput.get(index);
+                        RLBotDll.setPlayerInputFlatbuffer(output, index);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            System.out.println("Hive died because an exception occurred in the run loop!");
+            e.printStackTrace();
+        } finally {
+            retireHivemind(team); // Unregister this hivemind internally.
+            hivemind.retire(); // Tell the hivemind to clean up its resources.
+        }
+    }
+
+    public Set<Integer> getRunningBotIndices() {
+        Set<Integer> blueIndexes = hivemindProcesses[0].getDroneIndexes();
+        Set<Integer> orangeIndexes = hivemindProcesses[1].getDroneIndexes();
+
+        HashSet<Integer> allIndexes = new HashSet<>(blueIndexes);
+        allIndexes.addAll(orangeIndexes);
+        return allIndexes;
+    }
+
+    public void retireBot(int index) {
+        hivemindProcesses[0].retireDrone(index);
+        hivemindProcesses[1].retireDrone(index);
+    }
+
+    public void retireHivemind(int team) {
+        hivemindProcesses[team].stop();
+    }
+}

--- a/src/main/java/rlbot/manager/HivemindManager.java
+++ b/src/main/java/rlbot/manager/HivemindManager.java
@@ -9,7 +9,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 /**
  * This class is a BotManager for the hiveminds.
@@ -81,6 +80,32 @@ public class HivemindManager extends BaseBotManager {
         if (hivemindProcesses[0] != null && hivemindProcesses[0].runFlag.get()) allIndexes.addAll(hivemindProcesses[0].getDroneIndexes());
         if (hivemindProcesses[1] != null && hivemindProcesses[1].runFlag.get()) allIndexes.addAll(hivemindProcesses[1].getDroneIndexes());
         return allIndexes;
+    }
+
+    /**
+     * Returns a set of every blue bot index that is currently registered and running in this java process.
+     * Will not include indices from humans, bots in other languages, or bots in other java processes.
+     *
+     * This may be useful for driving a basic status display.
+     */
+    public Set<Integer> getRunningBotIndicesForBlue() {
+        if (hivemindProcesses[0] != null && hivemindProcesses[0].runFlag.get()) {
+            return hivemindProcesses[0].getDroneIndexes();
+        }
+        return new HashSet<>();
+    }
+
+    /**
+     * Returns a set of every orange bot index that is currently registered and running in this java process.
+     * Will not include indices from humans, bots in other languages, or bots in other java processes.
+     *
+     * This may be useful for driving a basic status display.
+     */
+    public Set<Integer> getRunningBotIndicesForOrange() {
+        if (hivemindProcesses[1] != null && hivemindProcesses[1].runFlag.get()) {
+            return hivemindProcesses[1].getDroneIndexes();
+        }
+        return new HashSet<>();
     }
 
     @Override

--- a/src/main/java/rlbot/manager/HivemindProcess.java
+++ b/src/main/java/rlbot/manager/HivemindProcess.java
@@ -7,8 +7,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public class HivemindProcess {
 
+    public AtomicBoolean runFlag;
+
     private final HashSet<Integer> droneIndexes = new HashSet<>();
-    private AtomicBoolean runFlag;
     private Thread thread;
 
     public HivemindProcess(Thread thread, final AtomicBoolean runFlag) {
@@ -22,6 +23,10 @@ public class HivemindProcess {
 
     public void stop() {
         runFlag.set(false);
+    }
+
+    public void ensureStarted() {
+        runFlag.set(true);
     }
 
     public void registerDrone(int index) {

--- a/src/main/java/rlbot/manager/HivemindProcess.java
+++ b/src/main/java/rlbot/manager/HivemindProcess.java
@@ -9,7 +9,7 @@ public class HivemindProcess {
 
     public AtomicBoolean runFlag;
 
-    private final HashSet<Integer> droneIndexes = new HashSet<>();
+    private final HashSet<Integer> droneIndices = new HashSet<>();
     private Thread thread;
 
     public HivemindProcess(Thread thread, final AtomicBoolean runFlag) {
@@ -31,19 +31,19 @@ public class HivemindProcess {
 
     public void registerDrone(int index) {
         synchronized (this) {
-            droneIndexes.add(index);
+            droneIndices.add(index);
         }
     }
 
     public void retireDrone(int index) {
         synchronized (this) {
-            droneIndexes.remove(index);
+            droneIndices.remove(index);
         }
     }
 
-    public Set<Integer> getDroneIndexes() {
+    public Set<Integer> getDroneIndices() {
         synchronized (this) {
-            return new HashSet<>(droneIndexes);
+            return new HashSet<>(droneIndices);
         }
     }
 }

--- a/src/main/java/rlbot/manager/HivemindProcess.java
+++ b/src/main/java/rlbot/manager/HivemindProcess.java
@@ -5,12 +5,15 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+/**
+ * This class contains information about a hivemind process and the indices that the hivemind controls.
+ */
 public class HivemindProcess {
 
-    public AtomicBoolean runFlag;
+    private final AtomicBoolean runFlag;
 
     private final HashSet<Integer> droneIndices = new HashSet<>();
-    private Thread thread;
+    private final Thread thread;
 
     public HivemindProcess(Thread thread, final AtomicBoolean runFlag) {
         this.thread = thread;
@@ -25,8 +28,8 @@ public class HivemindProcess {
         runFlag.set(false);
     }
 
-    public void ensureStarted() {
-        runFlag.set(true);
+    public boolean isRunning() {
+        return runFlag.get();
     }
 
     public void registerDrone(int index) {

--- a/src/main/java/rlbot/manager/HivemindProcess.java
+++ b/src/main/java/rlbot/manager/HivemindProcess.java
@@ -1,0 +1,44 @@
+package rlbot.manager;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class HivemindProcess {
+
+    private final HashSet<Integer> droneIndexes = new HashSet<>();
+    private AtomicBoolean runFlag;
+    private Thread thread;
+
+    public HivemindProcess(Thread thread, final AtomicBoolean runFlag) {
+        this.thread = thread;
+        this.runFlag = runFlag;
+    }
+
+    public Thread getThread() {
+        return thread;
+    }
+
+    public void stop() {
+        runFlag.set(false);
+    }
+
+    public void registerDrone(int index) {
+        synchronized (this) {
+            droneIndexes.add(index);
+        }
+    }
+
+    public void retireDrone(int index) {
+        synchronized (this) {
+            droneIndexes.remove(index);
+        }
+    }
+
+    public Set<Integer> getDroneIndexes() {
+        synchronized (this) {
+            return new HashSet<>(droneIndexes);
+        }
+    }
+}

--- a/src/main/java/rlbot/manager/IBotManager.java
+++ b/src/main/java/rlbot/manager/IBotManager.java
@@ -1,13 +1,8 @@
 package rlbot.manager;
 
-import rlbot.Bot;
-
 import java.util.Set;
-import java.util.function.Supplier;
 
 public interface IBotManager {
-
-    void ensureBotRegistered(final int index, final int team, final Supplier<Bot> botSupplier);
 
     void ensureStarted();
 

--- a/src/main/java/rlbot/manager/IBotManager.java
+++ b/src/main/java/rlbot/manager/IBotManager.java
@@ -1,0 +1,30 @@
+package rlbot.manager;
+
+import rlbot.Bot;
+
+import java.util.Set;
+import java.util.function.Supplier;
+
+public interface IBotManager {
+
+    void ensureBotRegistered(final int index, final int team, final Supplier<Bot> botSupplier);
+
+    void ensureStarted();
+
+    /**
+     * Returns a set of every bot index that is currently registered and running in this java process.
+     * Will not include indices from humans, bots in other languages, or bots in other java processes.
+     *
+     * This may be useful for driving a basic status display.
+     */
+    Set<Integer> getRunningBotIndices();
+
+    void shutDown();
+
+    void retireBot(int index);
+
+    /**
+     * Sets the maximum amount of packets your bot will receive per second
+     */
+    void setRefreshRate(int refreshRate);
+}

--- a/src/main/java/rlbot/pyinterop/BaseSocketServer.java
+++ b/src/main/java/rlbot/pyinterop/BaseSocketServer.java
@@ -1,0 +1,103 @@
+package rlbot.pyinterop;
+
+import rlbot.Bot;
+import rlbot.cppinterop.RLBotDll;
+import rlbot.manager.BotManager;
+import rlbot.manager.IBotManager;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+
+/**
+ * Listens for signals from the central RLBot framework which runs on python.
+ */
+public abstract class BaseSocketServer implements PythonInterface {
+
+    private final Integer port;
+    protected final IBotManager botManager;
+
+    public BaseSocketServer(final Integer port, IBotManager botManager) {
+        this.port = port;
+        this.botManager = botManager;
+    }
+
+    public void start() {
+
+        System.out.println(String.format("Listening for clients on 127.0.0.1 on port %s...", port));
+
+        try (ServerSocket serverSocket = new ServerSocket(port)) {
+            while (true) {
+                try (Socket clientSocket = serverSocket.accept()) {
+                    byte[] buffer = new byte[clientSocket.getReceiveBufferSize()];
+                    int bytes = clientSocket.getInputStream().read(buffer);
+                    String request = new String(buffer, 0, bytes);
+                    Command command = parseCommand(request);
+                    if (command.action == Command.Action.ADD) {
+                        ensureStarted(command.dllDirectory);
+                        ensureBotRegistered(command.index, command.name, command.team);
+                    } else if (command.action == Command.Action.REMOVE) {
+                        retireBot(command.index);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static Command parseCommand(final String socketCommand) {
+        String[] split = socketCommand.split("\n");
+
+        if (split.length < 2) {
+            throw new IllegalArgumentException("Server received too few command arguments from client");
+        }
+
+        Command command = new Command();
+
+        if ("add".equals(split[0])) {
+            command.action = Command.Action.ADD;
+            command.name = split[1];
+            command.team = Integer.parseInt(split[2]);
+            command.index = Integer.parseInt(split[3]);
+            command.dllDirectory = split[4];
+        }
+        else if ("remove".equals(split[0])) {
+            command.action = Command.Action.REMOVE;
+            command.index = Integer.parseInt(split[1]);
+        } else {
+            throw new IllegalArgumentException("Invalid command: " + split[0]);
+        }
+
+        return command;
+    }
+
+    protected void ensureStarted(final String interfaceDllPath) {
+        try {
+            RLBotDll.initialize(interfaceDllPath);
+            botManager.ensureStarted();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    protected void shutdown() {
+        System.out.println("Shutting down...");
+        botManager.shutDown();
+        try {
+            Thread.sleep(1500); // Wait for the bots to finish up
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        System.exit(0);
+    }
+
+    protected abstract void ensureBotRegistered(final int index, final String botType, final int team);
+
+    protected void retireBot(final int index) {
+        botManager.retireBot(index);
+        if (botManager.getRunningBotIndices().isEmpty()) {
+            shutdown();
+        }
+    }
+}

--- a/src/main/java/rlbot/pyinterop/BaseSocketServer.java
+++ b/src/main/java/rlbot/pyinterop/BaseSocketServer.java
@@ -1,8 +1,6 @@
 package rlbot.pyinterop;
 
-import rlbot.Bot;
 import rlbot.cppinterop.RLBotDll;
-import rlbot.manager.BotManager;
 import rlbot.manager.IBotManager;
 
 import java.io.IOException;

--- a/src/main/java/rlbot/pyinterop/HiveSocketServer.java
+++ b/src/main/java/rlbot/pyinterop/HiveSocketServer.java
@@ -3,7 +3,7 @@ package rlbot.pyinterop;
 import rlbot.Bot;
 import rlbot.manager.HivemindManager;
 
-public abstract class HiveSocketServer extends SocketServer {
+public abstract class HiveSocketServer extends BaseSocketServer {
 
     private final HivemindManager hivemindManager;
 
@@ -15,10 +15,5 @@ public abstract class HiveSocketServer extends SocketServer {
     @Override
     protected void ensureBotRegistered(int index, String botType, int team) {
         hivemindManager.ensureBotRegistered(index, team);
-    }
-
-    @Override
-    protected Bot initBot(int index, String botType, int team) {
-        return null;
     }
 }

--- a/src/main/java/rlbot/pyinterop/HiveSocketServer.java
+++ b/src/main/java/rlbot/pyinterop/HiveSocketServer.java
@@ -2,7 +2,7 @@ package rlbot.pyinterop;
 
 import rlbot.manager.HivemindManager;
 
-public abstract class HiveSocketServer extends BaseSocketServer {
+public class HiveSocketServer extends BaseSocketServer {
 
     private final HivemindManager hivemindManager;
 

--- a/src/main/java/rlbot/pyinterop/HiveSocketServer.java
+++ b/src/main/java/rlbot/pyinterop/HiveSocketServer.java
@@ -1,0 +1,24 @@
+package rlbot.pyinterop;
+
+import rlbot.Bot;
+import rlbot.manager.HivemindManager;
+
+public abstract class HiveSocketServer extends SocketServer {
+
+    private final HivemindManager hivemindManager;
+
+    public HiveSocketServer(Integer port, HivemindManager hivemindManager) {
+        super(port, hivemindManager);
+        this.hivemindManager = hivemindManager;
+    }
+
+    @Override
+    protected void ensureBotRegistered(int index, String botType, int team) {
+        hivemindManager.ensureBotRegistered(index, team);
+    }
+
+    @Override
+    protected Bot initBot(int index, String botType, int team) {
+        return null;
+    }
+}

--- a/src/main/java/rlbot/pyinterop/HiveSocketServer.java
+++ b/src/main/java/rlbot/pyinterop/HiveSocketServer.java
@@ -1,6 +1,5 @@
 package rlbot.pyinterop;
 
-import rlbot.Bot;
 import rlbot.manager.HivemindManager;
 
 public abstract class HiveSocketServer extends BaseSocketServer {

--- a/src/main/java/rlbot/pyinterop/SocketServer.java
+++ b/src/main/java/rlbot/pyinterop/SocketServer.java
@@ -92,7 +92,7 @@ public abstract class SocketServer implements PythonInterface {
     }
 
     protected void ensureBotRegistered(final int index, final String botType, final int team) {
-        botManager.ensureBotRegistered(index, () -> initBot(index, botType, team));
+        botManager.ensureBotRegistered(index, team, () -> initBot(index, botType, team));
     }
 
     protected void retireBot(final int index) {

--- a/src/main/java/rlbot/pyinterop/SocketServer.java
+++ b/src/main/java/rlbot/pyinterop/SocketServer.java
@@ -1,106 +1,21 @@
 package rlbot.pyinterop;
 
 import rlbot.Bot;
-import rlbot.cppinterop.RLBotDll;
 import rlbot.manager.BotManager;
 
-import java.io.IOException;
-import java.net.ServerSocket;
-import java.net.Socket;
+public abstract class SocketServer extends BaseSocketServer {
 
-/**
- * Listens for signals from the central RLBot framework which runs on python.
- */
-public abstract class SocketServer implements PythonInterface {
-
-    private final Integer port;
     private final BotManager botManager;
 
-    public SocketServer(final Integer port, BotManager botManager) {
-        this.port = port;
+    public SocketServer(Integer port, BotManager botManager) {
+        super(port, botManager);
         this.botManager = botManager;
     }
 
-    public void start() {
-
-        System.out.println(String.format("Listening for clients on 127.0.0.1 on port %s...", port));
-
-        try (ServerSocket serverSocket = new ServerSocket(port)) {
-            while (true) {
-                try (Socket clientSocket = serverSocket.accept()) {
-                    byte[] buffer = new byte[clientSocket.getReceiveBufferSize()];
-                    int bytes = clientSocket.getInputStream().read(buffer);
-                    String request = new String(buffer, 0, bytes);
-                    Command command = parseCommand(request);
-                    if (command.action == Command.Action.ADD) {
-                        ensureStarted(command.dllDirectory);
-                        ensureBotRegistered(command.index, command.name, command.team);
-                    } else if (command.action == Command.Action.REMOVE) {
-                        retireBot(command.index);
-                    }
-                }
-            }
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
-
-    private static Command parseCommand(final String socketCommand) {
-        String[] split = socketCommand.split("\n");
-
-        if (split.length < 2) {
-            throw new IllegalArgumentException("Server received too few command arguments from client");
-        }
-
-        Command command = new Command();
-
-        if ("add".equals(split[0])) {
-            command.action = Command.Action.ADD;
-            command.name = split[1];
-            command.team = Integer.parseInt(split[2]);
-            command.index = Integer.parseInt(split[3]);
-            command.dllDirectory = split[4];
-        }
-        else if ("remove".equals(split[0])) {
-            command.action = Command.Action.REMOVE;
-            command.index = Integer.parseInt(split[1]);
-        } else {
-            throw new IllegalArgumentException("Invalid command: " + split[0]);
-        }
-
-        return command;
-    }
-
-    protected void ensureStarted(final String interfaceDllPath) {
-        try {
-            RLBotDll.initialize(interfaceDllPath);
-            botManager.ensureStarted();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
-
-    protected void shutdown() {
-        System.out.println("Shutting down...");
-        botManager.shutDown();
-        try {
-            Thread.sleep(1500); // Wait for the bots to finish up
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
-        System.exit(0);
-    }
-
-    protected void ensureBotRegistered(final int index, final String botType, final int team) {
+    @Override
+    protected void ensureBotRegistered(int index, String botType, int team) {
         botManager.ensureBotRegistered(index, team, () -> initBot(index, botType, team));
     }
 
-    protected void retireBot(final int index) {
-        botManager.retireBot(index);
-        if (botManager.getRunningBotIndices().isEmpty()) {
-            shutdown();
-        }
-    }
-
-    protected abstract Bot initBot(final int index, final String botType, final int team);
+    protected abstract Bot initBot(int index, String botType, int team);
 }

--- a/src/test/java/rlbot/JavaExample.java
+++ b/src/test/java/rlbot/JavaExample.java
@@ -1,8 +1,6 @@
 package rlbot;
 
 import rlbot.manager.BotManager;
-import rlbot.manager.HivemindManager;
-import rlbot.pyinterop.HiveSocketServer;
 import rlbot.pyinterop.SocketServer;
 
 /**
@@ -16,14 +14,10 @@ public class JavaExample {
             throw new IllegalArgumentException("You must pass in a port as an argument!");
         }
 
-//        BotManager flatBotManager = new BotManager();
-//        flatBotManager.setRefreshRate(120);
-//        int port = Integer.parseInt(args[0]);
-//        SocketServer server = new SamplePythonInterface(port, flatBotManager);
-//        server.start();
-
-        HivemindManager hive = new HivemindManager(() -> new MyHivemind());
-        HiveSocketServer server = new HiveSocketServer(port, hive);
+        BotManager flatBotManager = new BotManager();
+        flatBotManager.setRefreshRate(120);
+        int port = Integer.parseInt(args[0]);
+        SocketServer server = new SamplePythonInterface(port, flatBotManager);
         server.start();
     }
 }

--- a/src/test/java/rlbot/JavaExample.java
+++ b/src/test/java/rlbot/JavaExample.java
@@ -1,6 +1,8 @@
 package rlbot;
 
 import rlbot.manager.BotManager;
+import rlbot.manager.HivemindManager;
+import rlbot.pyinterop.HiveSocketServer;
 import rlbot.pyinterop.SocketServer;
 
 /**

--- a/src/test/java/rlbot/JavaExample.java
+++ b/src/test/java/rlbot/JavaExample.java
@@ -1,6 +1,8 @@
 package rlbot;
 
 import rlbot.manager.BotManager;
+import rlbot.manager.HivemindManager;
+import rlbot.pyinterop.HiveSocketServer;
 import rlbot.pyinterop.SocketServer;
 
 /**
@@ -14,10 +16,14 @@ public class JavaExample {
             throw new IllegalArgumentException("You must pass in a port as an argument!");
         }
 
-        BotManager flatBotManager = new BotManager();
-        flatBotManager.setRefreshRate(120);
-        int port = Integer.parseInt(args[0]);
-        SocketServer server = new SamplePythonInterface(port, flatBotManager);
+//        BotManager flatBotManager = new BotManager();
+//        flatBotManager.setRefreshRate(120);
+//        int port = Integer.parseInt(args[0]);
+//        SocketServer server = new SamplePythonInterface(port, flatBotManager);
+//        server.start();
+
+        HivemindManager hive = new HivemindManager(() -> new MyHivemind());
+        HiveSocketServer server = new HiveSocketServer(port, hive);
         server.start();
     }
 }

--- a/src/test/java/rlbot/JavaExample.java
+++ b/src/test/java/rlbot/JavaExample.java
@@ -1,8 +1,6 @@
 package rlbot;
 
 import rlbot.manager.BotManager;
-import rlbot.manager.HivemindManager;
-import rlbot.pyinterop.HiveSocketServer;
 import rlbot.pyinterop.SocketServer;
 
 /**


### PR DESCRIPTION
This PR adds hivemind support for Java bots without breaking any backwards compatibility. Hiveminds are created very similarly to normal bots, except they they use the `HivemindManager` and the `HiveSocketServer` class:

```java
HivemindManager hivemindManager = new HivemindManager(team -> new MyHivemind(team));
HiveSocketServer server = new HiveSocketServer(port, hivemindManager);
server.start();
```
A tested example bot can be found at <https://github.com/NicEastvillage/RLBotJavaHivemindTemplate>