### PR TITLE
Multi-hivemind support for Java (and Kotlin)

### DIFF
--- a/src/main/java/rlbot/manager/HivemindCreator.java
+++ b/src/main/java/rlbot/manager/HivemindCreator.java
@@ -2,9 +2,19 @@ package rlbot.manager;
 
 import rlbot.Hivemind;
 
+/**
+ * This interface is used by the HivemindManager when multiple hiveminds per team is desired.
+ */
 public interface HivemindCreator {
 
+    /**
+     * Create a new hivemind instance.
+     */
     Hivemind createHivemind(int team, String hiveKey);
 
+    /**
+     * Assign a hive key to the newly registered bot. This key will decide which hivemind the bot will
+     * be controlled by.
+     */
     String assignHiveKey(int index, int team, String botName);
 }

--- a/src/main/java/rlbot/manager/HivemindCreator.java
+++ b/src/main/java/rlbot/manager/HivemindCreator.java
@@ -3,7 +3,7 @@ package rlbot.manager;
 import rlbot.Hivemind;
 
 /**
- * This interface is used by the HivemindManager when multiple hiveminds per team is desired.
+ * This interface is used by the HivemindManager when multiple hiveminds per team are desired.
  */
 public interface HivemindCreator {
 

--- a/src/main/java/rlbot/manager/HivemindCreator.java
+++ b/src/main/java/rlbot/manager/HivemindCreator.java
@@ -1,0 +1,10 @@
+package rlbot.manager;
+
+import rlbot.Hivemind;
+
+public interface HivemindCreator {
+
+    Hivemind createHivemind(int team, String hiveKey);
+
+    String assignHiveKey(int index, int team, String botName);
+}

--- a/src/main/java/rlbot/manager/HivemindManager.java
+++ b/src/main/java/rlbot/manager/HivemindManager.java
@@ -17,10 +17,18 @@ import java.util.function.Function;
  */
 public class HivemindManager extends BaseBotManager {
 
+    private final static String BLUE_POSTFIX = " [blue]";
+    private final static String ORANGE_POSTFIX = " [orange]";
+
+    // Each hivemind is associated with a hive key. The postfixes "[blue]" or "[orange]" is used
+    // to differentiate between teams
     private final Map<String, HivemindProcess> hivemindProcesses = new ConcurrentHashMap<>();
     private final Map<Integer, HivemindProcess> hivemindProcessOfDrone = new ConcurrentHashMap<>();
     private final HivemindCreator hivemindCreator;
 
+    /**
+     * Create a HivemindManager, that only administrates one hivemind per team. Their hive key will be "Default".
+     */
     public HivemindManager(Function<Integer, Hivemind> hivemindSupplier) {
         hivemindCreator = new HivemindCreator() {
             @Override
@@ -30,11 +38,16 @@ public class HivemindManager extends BaseBotManager {
 
             @Override
             public String assignHiveKey(int index, int team, String botName) {
+                // No HivemindCreator provided, so the key will just be "Default"
                 return "Default";
             }
         };
     }
 
+    /**
+     * Create a HivemindManager able to manage multiple hiveminds. Each hivemind is associated with a hive key,
+     * which is assigned to newly registered bots by the given HivemindCreator.
+     */
     public HivemindManager(HivemindCreator hivemindCreator) {
         this.hivemindCreator = hivemindCreator;
     }
@@ -47,7 +60,7 @@ public class HivemindManager extends BaseBotManager {
         }
 
         String hiveKey = hivemindCreator.assignHiveKey(index, team, botName);
-        String coloredHiveKey = hiveKey + (team == 0 ? " [blue]" : " [orange]");
+        String coloredHiveKey = hiveKey + (team == 0 ? BLUE_POSTFIX : ORANGE_POSTFIX);
 
         HivemindProcess hivemindProcess = hivemindProcesses.computeIfAbsent(coloredHiveKey, (nhk) -> {
             // Start a new instance of the hivemind
@@ -113,7 +126,7 @@ public class HivemindManager extends BaseBotManager {
      * This may be useful for driving a basic status display.
      */
     public Set<Integer> getRunningBotIndices(int team, String hiveKey) {
-        String coloredHiveKey = hiveKey + (team == 0 ? " [blue]" : " [orange]");
+        String coloredHiveKey = hiveKey + (team == 0 ? BLUE_POSTFIX : ORANGE_POSTFIX);
         HivemindProcess hivemindProcess = hivemindProcesses.get(coloredHiveKey);
         if (hivemindProcess == null) return new HashSet<>();
         return hivemindProcess.getDroneIndices();

--- a/src/main/java/rlbot/manager/HivemindManager.java
+++ b/src/main/java/rlbot/manager/HivemindManager.java
@@ -20,7 +20,7 @@ public class HivemindManager extends BaseBotManager {
     private final static String BLUE_POSTFIX = " [blue]";
     private final static String ORANGE_POSTFIX = " [orange]";
 
-    // Each hivemind is associated with a hive key. The postfixes "[blue]" or "[orange]" is used
+    // Each hivemind is associated with a hive key. The postfixes "[blue]" or "[orange]" are used
     // to differentiate between teams
     private final Map<String, HivemindProcess> hivemindProcesses = new ConcurrentHashMap<>();
     private final Map<Integer, HivemindProcess> hivemindProcessOfDrone = new ConcurrentHashMap<>();

--- a/src/main/java/rlbot/manager/HivemindManager.java
+++ b/src/main/java/rlbot/manager/HivemindManager.java
@@ -7,6 +7,7 @@ import rlbot.cppinterop.RLBotDll;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
@@ -16,28 +17,52 @@ import java.util.function.Function;
  */
 public class HivemindManager extends BaseBotManager {
 
-    // There are only ever two hiveminds of this bot, once for each team
-    private final HivemindProcess[] hivemindProcesses = new HivemindProcess[2];
-    private final Function<Integer, Hivemind> hivemindSupplier;
+    private final Map<String, HivemindProcess> hivemindProcesses = new ConcurrentHashMap<>();
+    private final Map<Integer, HivemindProcess> hivemindProcessOfDrone = new ConcurrentHashMap<>();
+    private final HivemindCreator hivemindCreator;
 
     public HivemindManager(Function<Integer, Hivemind> hivemindSupplier) {
-        this.hivemindSupplier = hivemindSupplier;
+        hivemindCreator = new HivemindCreator() {
+            @Override
+            public Hivemind createHivemind(int team, String hiveKey) {
+                return hivemindSupplier.apply(team);
+            }
+
+            @Override
+            public String assignHiveKey(int index, int team, String botName) {
+                return "Default";
+            }
+        };
     }
 
-    public void ensureBotRegistered(int index, int team) {
-        if (hivemindProcesses[team] == null || !hivemindProcesses[team].isRunning()) {
-            // Start a new instance of the hivemind
-            Hivemind hivemind = hivemindSupplier.apply(team);
-            final AtomicBoolean runFlag = new AtomicBoolean(true);
-            Thread hiveTread = new Thread(() -> doHiveLoop(hivemind, team, runFlag));
-            hiveTread.start();
-            hivemindProcesses[team] = new HivemindProcess(hiveTread, runFlag);
+    public HivemindManager(HivemindCreator hivemindCreator) {
+        this.hivemindCreator = hivemindCreator;
+    }
+
+    public void ensureBotRegistered(int index, int team, String botName) {
+
+        // Is this drone already registered somewhere?
+        if (hivemindProcessOfDrone.containsKey(index)) {
+            return;
         }
 
-        hivemindProcesses[team].registerDrone(index);
+        String hiveKey = hivemindCreator.assignHiveKey(index, team, botName);
+        String coloredHiveKey = hiveKey + (team == 0 ? " [blue]" : " [orange]");
+
+        HivemindProcess hivemindProcess = hivemindProcesses.computeIfAbsent(coloredHiveKey, (nhk) -> {
+            // Start a new instance of the hivemind
+            Hivemind hivemind = hivemindCreator.createHivemind(team, hiveKey);
+            final AtomicBoolean runFlag = new AtomicBoolean(true);
+            Thread hiveTread = new Thread(() -> doHiveLoop(hivemind, coloredHiveKey, team, runFlag));
+            hiveTread.start();
+            return new HivemindProcess(hiveTread, runFlag, coloredHiveKey);
+        });
+
+        hivemindProcess.registerDrone(index);
+        hivemindProcessOfDrone.put(index, hivemindProcess);
     }
 
-    private void doHiveLoop(Hivemind hivemind, final int team, final AtomicBoolean runFlag) {
+    private void doHiveLoop(Hivemind hivemind, final String coloredHiveKey, final int team, final AtomicBoolean runFlag) {
 
         try {
             while (keepRunning && runFlag.get()) {
@@ -48,7 +73,7 @@ public class HivemindManager extends BaseBotManager {
                 }
                 if (latestPacket != null) {
 
-                    Set<Integer> droneIndices = hivemindProcesses[team].getDroneIndices();
+                    Set<Integer> droneIndices = hivemindProcesses.get(coloredHiveKey).getDroneIndices();
                     if (droneIndices.isEmpty()) continue;
                     Map<Integer, ControllerState> hivemindOutput = hivemind.processInput(droneIndices, latestPacket);
 
@@ -71,52 +96,52 @@ public class HivemindManager extends BaseBotManager {
             System.out.println("Hive died because an exception occurred in the run loop!");
             e.printStackTrace();
         } finally {
-            retireHivemind(team); // Unregister this hivemind internally.
+            retireHivemind(coloredHiveKey); // Unregister this hivemind internally.
             hivemind.retire(); // Tell the hivemind to clean up its resources.
         }
     }
 
     @Override
     public Set<Integer> getRunningBotIndices() {
-        HashSet<Integer> allIndices = new HashSet<>();
-        if (hivemindProcesses[0] != null && hivemindProcesses[0].isRunning()) allIndices.addAll(hivemindProcesses[0].getDroneIndices());
-        if (hivemindProcesses[1] != null && hivemindProcesses[1].isRunning()) allIndices.addAll(hivemindProcesses[1].getDroneIndices());
-        return allIndices;
+        return hivemindProcessOfDrone.keySet();
     }
 
     /**
-     * Returns a set of every blue bot index that is currently registered and running in this java process.
+     * Returns a set of every bot index that is currently registered and running for the give hive and team.
      * Will not include indices from humans, bots in other languages, or bots in other java processes.
      *
      * This may be useful for driving a basic status display.
      */
-    public Set<Integer> getRunningBotIndicesForBlue() {
-        if (hivemindProcesses[0] != null && hivemindProcesses[0].isRunning()) {
-            return hivemindProcesses[0].getDroneIndices();
-        }
-        return new HashSet<>();
-    }
-
-    /**
-     * Returns a set of every orange bot index that is currently registered and running in this java process.
-     * Will not include indices from humans, bots in other languages, or bots in other java processes.
-     *
-     * This may be useful for driving a basic status display.
-     */
-    public Set<Integer> getRunningBotIndicesForOrange() {
-        if (hivemindProcesses[1] != null && hivemindProcesses[1].isRunning()) {
-            return hivemindProcesses[1].getDroneIndices();
-        }
-        return new HashSet<>();
+    public Set<Integer> getRunningBotIndices(int team, String hiveKey) {
+        String coloredHiveKey = hiveKey + (team == 0 ? " [blue]" : " [orange]");
+        HivemindProcess hivemindProcess = hivemindProcesses.get(coloredHiveKey);
+        if (hivemindProcess == null) return new HashSet<>();
+        return hivemindProcess.getDroneIndices();
     }
 
     @Override
     public void retireBot(int index) {
-        if (hivemindProcesses[0] != null) hivemindProcesses[0].retireDrone(index);
-        if (hivemindProcesses[1] != null) hivemindProcesses[1].retireDrone(index);
+        HivemindProcess hivemindProcess = hivemindProcessOfDrone.get(index);
+        if (hivemindProcess != null) {
+            hivemindProcess.retireDrone(index);
+            hivemindProcessOfDrone.remove(index);
+            // If the hive is now empty, we will retire it
+            if (hivemindProcess.getDroneIndices().isEmpty()) {
+                retireHivemind(hivemindProcess.getHiveKey());
+            }
+        }
     }
 
-    public void retireHivemind(int team) {
-        hivemindProcesses[team].stop();
+    /**
+     * Stop the hivemind process with the given coloredHiveKey (with team postfix) and unregister the drones indices.
+     */
+    public void retireHivemind(String coloredHiveKey) {
+        HivemindProcess hivemindProcess = hivemindProcesses.get(coloredHiveKey);
+        if (hivemindProcess != null) {
+            hivemindProcess.stop();
+            for (int index : hivemindProcess.getDroneIndices()) {
+                hivemindProcessOfDrone.remove(index);
+            }
+        }
     }
 }

--- a/src/main/java/rlbot/manager/HivemindProcess.java
+++ b/src/main/java/rlbot/manager/HivemindProcess.java
@@ -14,10 +14,12 @@ public class HivemindProcess {
 
     private final HashSet<Integer> droneIndices = new HashSet<>();
     private final Thread thread;
+    private final String hiveKey;
 
-    public HivemindProcess(Thread thread, final AtomicBoolean runFlag) {
+    public HivemindProcess(Thread thread, final AtomicBoolean runFlag, String hiveKey) {
         this.thread = thread;
         this.runFlag = runFlag;
+        this.hiveKey = hiveKey;
     }
 
     public Thread getThread() {
@@ -30,6 +32,10 @@ public class HivemindProcess {
 
     public boolean isRunning() {
         return runFlag.get();
+    }
+
+    public String getHiveKey() {
+        return hiveKey;
     }
 
     public void registerDrone(int index) {

--- a/src/main/java/rlbot/pyinterop/HiveSocketServer.java
+++ b/src/main/java/rlbot/pyinterop/HiveSocketServer.java
@@ -13,6 +13,6 @@ public class HiveSocketServer extends BaseSocketServer {
 
     @Override
     protected void ensureBotRegistered(int index, String botType, int team) {
-        hivemindManager.ensureBotRegistered(index, team);
+        hivemindManager.ensureBotRegistered(index, team, botType);
     }
 }


### PR DESCRIPTION
A remake of the java `HivemindManager`. Now multiple hives can exist per team in the rare case that users wants to do that. If the user only wants a single hive, they are created exactly the same way as before:
```java
HivemindManager hivemindManager = new HivemindManager(team -> new MyHivemind(team));
HiveSocketServer server = new HiveSocketServer(port, hivemindManager);
server.start();
```
If they want to have multiple hiveminds, they must create a `HivemindCreator` that can assign hive keys to bots. A stupid example follows:
```java
HivemindManager hivemindManager = new HivemindManager(new HivemindCreator() {
    @Override
    public Hivemind createHivemind(int team, String hiveKey) {
        return new MyHivemind(team);
    }

    @Override
    public String assignHiveKey(int index, int team, String botName) {
        return new Random().nextBoolean() ? "Default" : "NotDefault";
    }
});
HiveSocketServer server = new HiveSocketServer(port, hivemindManager);
new Thread(server::start).start();
```
This version works more like the original `BotManager` since it doesn't have one `HivemindProcess` per team, but uses hive keys.

A tested example can also be found as the [multi-hivemind-example](https://github.com/NicEastvillage/RLBotJavaHivemindTemplate/tree/multi-hivemind-example) branch of the java hivemind template.