### PR TITLE
Fixed Python Hiveminds

### DIFF
--- a/src/main/python/rlbot/agents/hivemind/python_hivemind.py
+++ b/src/main/python/rlbot/agents/hivemind/python_hivemind.py
@@ -97,7 +97,7 @@ class PythonHivemind(BotHelperProcess):
         while not self.quit_event.is_set():
             try:
                 # Updating the packet.
-                self.game_interface.fresh_live_data_packet(packet, 20, key)
+                self.game_interface.fresh_live_data_packet(packet, 20, first_index)
 
                 # Get outputs from hivemind for each bot.
                 # Outputs are expected to be a Dict[int, PlayerInput]


### PR DESCRIPTION
Turns out making PRs when tired is not a great idea. I forgot to rename all appearances of `key` in PR #502 which broke Python hiveminds.