### PR TITLE
Allow Psyonix bots to be preconfigured with a loadout

### DIFF
--- a/src/main/python/rlbot/setup_manager.py
+++ b/src/main/python/rlbot/setup_manager.py
@@ -249,7 +249,7 @@ class SetupManager:
         self.teams = [bot.team for bot in match_config.player_configs]
 
         for player in match_config.player_configs:
-            if player.bot and not player.rlbot_controlled:
+            if player.bot and not player.rlbot_controlled and not player.loadout_config:
                 set_random_psyonix_bot_preset(player)
 
         bundles = [bot_config_overrides[index] if index in bot_config_overrides else


### PR DESCRIPTION
If a PlayerConfig is a psyonix bot then it's loadout config
was always being overwrriten. However, if the loadout was
specifically set, then we should just respect it.