### PR TITLE
Fix currentID initialization in MessageBase constructor

### DIFF
--- a/src/main/cpp/RLBotInterface/src/RLBotMessages/MessageStructs/Message.hpp
+++ b/src/main/cpp/RLBotInterface/src/RLBotMessages/MessageStructs/Message.hpp
@@ -26,7 +26,7 @@ struct MessageBase
 protected:
 	MessageBase(MessageType type, bool hasCallback) : Type(type), HasCallback(hasCallback)
 	{
-		static std::atomic_uint currentID = {0};
+		static std::atomic_uint currentID(0);
 		ID = currentID++;
 	}
 };

--- a/src/main/cpp/RLBotInterface/src/RLBotMessages/MessageStructs/Message.hpp
+++ b/src/main/cpp/RLBotInterface/src/RLBotMessages/MessageStructs/Message.hpp
@@ -26,7 +26,7 @@ struct MessageBase
 protected:
 	MessageBase(MessageType type, bool hasCallback) : Type(type), HasCallback(hasCallback)
 	{
-		static std::atomic_uint currentID = 0;
+		static std::atomic_uint currentID = {0};
 		ID = currentID++;
 	}
 };


### PR DESCRIPTION
Resolves compilation error "`copying variable of type 'std::atomic_uint' (aka 'atomic<unsigned int>') invokes deleted constructor`" that appears when using `clang` (for `rlbot-rust` binding generation). There's a few questions on Stack Overflow that describe the issue in greater detail if you're curious.

Haven't tested using the [instructions from the README](https://github.com/RLBot/RLBot/blob/cbe257682f70909c27c2f1c35d9b32f7bd4cf5a3/src/main/cpp/RLBotInterface/README.md) because I don't have Visual Studio installed, sorry! It's a very minor change anyways.