### PR TITLE
Adding virtual environment support for standalone bots.

### DIFF
--- a/src/main/python/rlbot/agents/rlbot_runnable.py
+++ b/src/main/python/rlbot/agents/rlbot_runnable.py
@@ -8,6 +8,7 @@ LOGO_FILE_KEY = 'logo_file'
 NAME_KEY = "name"
 SUPPORTS_EARLY_START_KEY = "supports_early_start"
 REQUIRES_TKINTER = "requires_tkinter"
+SUPPORTS_VENV_KEY = "supports_venv"
 
 
 class RLBotRunnable:
@@ -71,6 +72,8 @@ class RLBotRunnable:
                                   description="True if this bot can be started before the Rocket League match begins.")
         location_config.add_value(REQUIRES_TKINTER, bool,
                                   description="True if the tkinter library is needed.")
+        location_config.add_value(SUPPORTS_VENV_KEY, bool,
+                                  description="True if the runnable wants to run in a virtual environment.")
 
         details_config = config.add_header_name(DETAILS_HEADER)
         details_config.add_value('developer', str, description="Name of the bot's creator/developer")

--- a/src/main/python/rlbot/agents/rlbot_runnable.py
+++ b/src/main/python/rlbot/agents/rlbot_runnable.py
@@ -8,7 +8,7 @@ LOGO_FILE_KEY = 'logo_file'
 NAME_KEY = "name"
 SUPPORTS_EARLY_START_KEY = "supports_early_start"
 REQUIRES_TKINTER = "requires_tkinter"
-SUPPORTS_VENV_KEY = "supports_venv"
+USE_VIRTUAL_ENVIRONMENT_KEY = "use_virtual_environment"
 
 
 class RLBotRunnable:
@@ -72,7 +72,7 @@ class RLBotRunnable:
                                   description="True if this bot can be started before the Rocket League match begins.")
         location_config.add_value(REQUIRES_TKINTER, bool,
                                   description="True if the tkinter library is needed.")
-        location_config.add_value(SUPPORTS_VENV_KEY, bool,
+        location_config.add_value(USE_VIRTUAL_ENVIRONMENT_KEY, bool,
                                   description="True if the runnable wants to run in a virtual environment.")
 
         details_config = config.add_header_name(DETAILS_HEADER)

--- a/src/main/python/rlbot/agents/standalone/standalone_bot.py
+++ b/src/main/python/rlbot/agents/standalone/standalone_bot.py
@@ -80,6 +80,6 @@ def run_bot(agent_class: Type[StandaloneBot]):
                                   agent_class_wrapper=agent_class_wrapper,
                                   agent_metadata_queue=mp.Queue(),
                                   match_config=None,
-                                  matchcomms_root=None,
+                                  matchcomms_root=config.matchcomms_url,
                                   spawn_id=spawn_id)
     bot_manger.run()

--- a/src/main/python/rlbot/agents/standalone/standalone_bot.py
+++ b/src/main/python/rlbot/agents/standalone/standalone_bot.py
@@ -36,16 +36,16 @@ class StandaloneBot(BaseAgent):
 
 def run_bot(agent_class: Type[StandaloneBot]):
     config = StandaloneBotConfig(sys.argv)
+    python_file = inspect.getfile(agent_class)
 
     config_obj = agent_class.base_create_agent_configurations()
     bundle = None
     if config.config_file is not None:
         # If the config file was not passed, then the bot will miss out on any custom configuration,
         # tick rate preference, etc.
-        bundle = get_bot_config_bundle(config.config_file)
+        bundle = get_bot_config_bundle(Path(python_file).parent / config.config_file)
         config_obj.parse_file(bundle.config_obj, config_directory=bundle.config_directory)
 
-    python_file = inspect.getfile(agent_class)
     spawn_id = config.spawn_id
     player_index = config.player_index
     team = config.team

--- a/src/main/python/rlbot/agents/standalone/standalone_bot_config.py
+++ b/src/main/python/rlbot/agents/standalone/standalone_bot_config.py
@@ -1,7 +1,7 @@
 """Standalone Bot Script
 
 Usage:
-    standalone [--player-index=0] [--config-file=C:/Users/t/code/myBot.cfg] [--name=MyBot] [--team=0] [--spawn-id=23245]
+    standalone [--player-index=0] [--config-file=C:/Users/t/code/myBot.cfg] [--name=MyBot] [--team=0] [--spawn-id=23245] [--matchcomms-url=ws://localhost:49468]
 
 Options:
     --player-index=I             Index that the player is running under. Will be passed to your bot's constructor.
@@ -9,10 +9,12 @@ Options:
     --name=N                     Name that will be passed to your bot's constructor. Does not influence in-game name.
     --team=T                     Team the bot is playing on, 0 for blue, 1 for orange. Will be passed to your bot's constructor.
     --spawn-id=S                 Spawn identifier used to confirm the right car in the packet.
+    --matchcomms-url=M           A url that can be used to connect with the matchcomms system.
 """
-from typing import List
+from typing import List, Union
 
 from docopt import docopt, DocoptExit, printable_usage
+from urllib.parse import ParseResult, urlparse
 
 
 class StandaloneBotConfig:
@@ -24,14 +26,21 @@ class StandaloneBotConfig:
         self.player_index = self.int_or_none(arguments['--player-index'])
         self.spawn_id = self.int_or_none(arguments['--spawn-id'])
         self.config_file = arguments['--config-file']
+        self.matchcomms_url = self.url_or_none(arguments['--matchcomms-url'])
         self.is_missing_args = False
-        
-        if self.name is None or self.team is None or self.player_index is None or self.spawn_id is None or self.config_file is None:
+
+        if self.name is None or self.team is None or self.player_index is None or self.spawn_id is None \
+                or self.config_file is None or self.matchcomms_url is None:
             print('Standalone bot is missing required arguments!')
             print(printable_usage(__doc__))
             self.is_missing_args = True
 
-    def int_or_none(self, val):
+    def int_or_none(self, val) -> Union[int, None]:
         if val:
             return int(val)
+        return None
+
+    def url_or_none(self, val) -> Union[ParseResult, None]:
+        if val:
+            return urlparse(val)
         return None

--- a/src/main/python/rlbot/parsing/bot_config_bundle.py
+++ b/src/main/python/rlbot/parsing/bot_config_bundle.py
@@ -10,7 +10,7 @@ from rlbot.agents.base_agent import BaseAgent, BOT_CONFIG_MODULE_HEADER, BOT_NAM
     PYTHON_FILE_KEY, LOGO_FILE_KEY, SUPPORTS_EARLY_START_KEY, LOADOUT_GENERATOR_FILE_KEY, SUPPORTS_STANDALONE
 from rlbot.agents.base_loadout_generator import BaseLoadoutGenerator
 from rlbot.agents.base_script import SCRIPT_FILE_KEY, BaseScript
-from rlbot.agents.rlbot_runnable import RLBotRunnable, REQUIREMENTS_FILE_KEY, REQUIRES_TKINTER, SUPPORTS_VENV_KEY
+from rlbot.agents.rlbot_runnable import RLBotRunnable, REQUIREMENTS_FILE_KEY, REQUIRES_TKINTER, USE_VIRTUAL_ENVIRONMENT_KEY
 from rlbot.utils.requirements_management import get_missing_packages, get_packages_needing_upgrade
 from rlbot.matchconfig.loadout_config import LoadoutConfig
 from rlbot.parsing.agent_config_parser import create_looks_configurations, PARTICIPANT_CONFIGURATION_HEADER, \
@@ -33,7 +33,7 @@ class RunnableConfigBundle:
         self.name = config_obj.get(BOT_CONFIG_MODULE_HEADER, BOT_NAME_KEY)
         self.supports_early_start = self.base_agent_config.get(BOT_CONFIG_MODULE_HEADER, SUPPORTS_EARLY_START_KEY)
         self.requirements_file = self.get_absolute_path(BOT_CONFIG_MODULE_HEADER, REQUIREMENTS_FILE_KEY)
-        self.supports_virtual_environment = self.base_agent_config.getboolean(BOT_CONFIG_MODULE_HEADER, SUPPORTS_VENV_KEY)
+        self.use_virtual_environment = self.base_agent_config.getboolean(BOT_CONFIG_MODULE_HEADER, USE_VIRTUAL_ENVIRONMENT_KEY)
 
     def get_logo_file(self):
         # logo.png is a convention we established during the wintertide tournament.
@@ -59,14 +59,14 @@ class RunnableConfigBundle:
         if self.base_agent_config.getboolean(BOT_CONFIG_MODULE_HEADER, REQUIRES_TKINTER):
             special_reqs.append('tkinter')
 
-        if self.supports_virtual_environment:
+        if self.use_virtual_environment:
             # Ignore the requirements file for now, because we will be installing it automatically later!
             return get_missing_packages(requirements_file=None, special_reqs=special_reqs)
         else:
             return get_missing_packages(requirements_file=self.requirements_file, special_reqs=special_reqs)
 
     def get_python_packages_needing_upgrade(self) -> List[Requirement]:
-        if self.requirements_file and not self.supports_virtual_environment:
+        if self.requirements_file and not self.use_virtual_environment:
             return get_packages_needing_upgrade(requirements_file=self.requirements_file)
         return []
 

--- a/src/main/python/rlbot/parsing/bot_config_bundle.py
+++ b/src/main/python/rlbot/parsing/bot_config_bundle.py
@@ -10,7 +10,7 @@ from rlbot.agents.base_agent import BaseAgent, BOT_CONFIG_MODULE_HEADER, BOT_NAM
     PYTHON_FILE_KEY, LOGO_FILE_KEY, SUPPORTS_EARLY_START_KEY, LOADOUT_GENERATOR_FILE_KEY, SUPPORTS_STANDALONE
 from rlbot.agents.base_loadout_generator import BaseLoadoutGenerator
 from rlbot.agents.base_script import SCRIPT_FILE_KEY, BaseScript
-from rlbot.agents.rlbot_runnable import RLBotRunnable, REQUIREMENTS_FILE_KEY, REQUIRES_TKINTER
+from rlbot.agents.rlbot_runnable import RLBotRunnable, REQUIREMENTS_FILE_KEY, REQUIRES_TKINTER, SUPPORTS_VENV_KEY
 from rlbot.utils.requirements_management import get_missing_packages, get_packages_needing_upgrade
 from rlbot.matchconfig.loadout_config import LoadoutConfig
 from rlbot.parsing.agent_config_parser import create_looks_configurations, PARTICIPANT_CONFIGURATION_HEADER, \
@@ -33,6 +33,7 @@ class RunnableConfigBundle:
         self.name = config_obj.get(BOT_CONFIG_MODULE_HEADER, BOT_NAME_KEY)
         self.supports_early_start = self.base_agent_config.get(BOT_CONFIG_MODULE_HEADER, SUPPORTS_EARLY_START_KEY)
         self.requirements_file = self.get_absolute_path(BOT_CONFIG_MODULE_HEADER, REQUIREMENTS_FILE_KEY)
+        self.supports_virtual_environment = self.base_agent_config.getboolean(BOT_CONFIG_MODULE_HEADER, SUPPORTS_VENV_KEY)
 
     def get_logo_file(self):
         # logo.png is a convention we established during the wintertide tournament.
@@ -57,10 +58,15 @@ class RunnableConfigBundle:
         special_reqs = []
         if self.base_agent_config.getboolean(BOT_CONFIG_MODULE_HEADER, REQUIRES_TKINTER):
             special_reqs.append('tkinter')
-        return get_missing_packages(requirements_file=self.requirements_file, special_reqs=special_reqs)
+
+        if self.supports_virtual_environment:
+            # Ignore the requirements file for now, because we will be installing it automatically later!
+            return get_missing_packages(requirements_file=None, special_reqs=special_reqs)
+        else:
+            return get_missing_packages(requirements_file=self.requirements_file, special_reqs=special_reqs)
 
     def get_python_packages_needing_upgrade(self) -> List[Requirement]:
-        if self.requirements_file:
+        if self.requirements_file and not self.supports_virtual_environment:
             return get_packages_needing_upgrade(requirements_file=self.requirements_file)
         return []
 

--- a/src/main/python/rlbot/setup_manager.py
+++ b/src/main/python/rlbot/setup_manager.py
@@ -306,9 +306,15 @@ class SetupManager:
             self.load_extension(match_config.extension_config.python_file_path)
 
         for bundle in self.bot_bundles:
-            if bundle is not None and bundle.supports_virtual_environment:
+            if bundle is not None and bundle.use_virtual_environment:
                 builder = EnvBuilderWithRequirements(bundle=bundle)
                 builder.create(Path(bundle.config_directory) / 'venv')
+
+        for script_config in match_config.script_configs:
+            script_config_bundle = get_script_config_bundle(script_config.config_path)
+            if script_config_bundle.use_virtual_environment:
+                builder = EnvBuilderWithRequirements(bundle=script_config_bundle)
+                builder.create(Path(script_config_bundle.config_directory) / 'venv')
 
         self.match_config = match_config
         self.start_match_configuration = match_config.create_match_settings()
@@ -448,17 +454,18 @@ class SetupManager:
                 name = str(self.start_match_configuration.player_configuration[i].name)
                 if bundle.supports_standalone:
                     executable = sys.executable
-                    if bundle.supports_virtual_environment:
-                        executable = Path(bundle.config_directory) / 'venv' / 'Scripts' / 'python.exe'
+                    if bundle.use_virtual_environment:
+                        executable = str(Path(bundle.config_directory) / 'venv' / 'Scripts' / 'python.exe')
                     process = subprocess.Popen([
                         executable,
                         bundle.python_file,
-                        '--config-file', player_config.config_path,
+                        '--config-file', str(player_config.config_path),
                         '--name', name,
                         '--team', str(self.teams[i]),
                         '--player-index', str(participant_index),
-                        '--spawn-id', str(spawn_id)
-                    ], shell=True, cwd=Path(bundle.config_directory).parent)
+                        '--spawn-id', str(spawn_id),
+                        '--matchcomms-url', self.matchcomms_server.root_url.geturl()
+                    ], cwd=Path(bundle.config_directory).parent)
                     self.bot_processes[participant_index] = BotProcessInfo(process=None, subprocess=process, player_config=player_config)
 
                     # Insert immediately into the agent metadata map because the standalone process has no way to communicate it back out
@@ -486,8 +493,12 @@ class SetupManager:
             script_config_bundle = get_script_config_bundle(script_config.config_path)
             if early_starters_only and not script_config_bundle.supports_early_start:
                 continue
-            process = subprocess.Popen([sys.executable, script_config_bundle.script_file],
-                                       shell=True, cwd=Path(script_config_bundle.config_directory).parent)
+            executable = sys.executable
+            if script_config_bundle.use_virtual_environment:
+                executable = str(Path(script_config_bundle.config_directory) / 'venv' / 'Scripts' / 'python.exe')
+
+            process = subprocess.Popen([executable, script_config_bundle.script_file],
+                                       cwd=Path(script_config_bundle.config_directory).parent)
             self.logger.info(f"Started script with pid {process.pid} using {process.args}")
             self.script_processes[process.pid] = process
             scripts_started += 1
@@ -665,9 +676,11 @@ class SetupManager:
 
     def kill_bot_processes(self):
         for process_info in self.bot_processes.values():
-            process_info.process.terminate()
+            proc = process_info.process or process_info.subprocess
+            proc.terminate()
         for process_info in self.bot_processes.values():
-            process_info.process.join(timeout=1)
+            if process_info.process:
+                process_info.process.join(timeout=1)
         self.bot_processes.clear()
         self.num_metadata_received = 0
 
@@ -679,12 +692,12 @@ class SetupManager:
                     self.logger.info(f"Killing {child.pid} (child of {pid})")
                     try:
                         child.kill()
-                    except psutil._exceptions.NoSuchProcess:
+                    except psutil.NoSuchProcess:
                         self.logger.info("Already dead.")
                 self.logger.info(f"Killing {pid}")
                 try:
                     parent.kill()
-                except psutil._exceptions.NoSuchProcess:
+                except psutil.NoSuchProcess:
                     self.logger.info("Already dead.")
             except psutil.NoSuchProcess:
                 self.logger.info("Can't fetch parent process, already dead.")

--- a/src/main/python/rlbot/utils/virtual_environment_management.py
+++ b/src/main/python/rlbot/utils/virtual_environment_management.py
@@ -1,0 +1,49 @@
+import sys
+from pathlib import Path
+from subprocess import PIPE, Popen, run
+from threading import Thread
+from types import SimpleNamespace
+from typing import List
+from venv import EnvBuilder
+
+from rlbot.parsing.bot_config_bundle import RunnableConfigBundle
+
+
+class EnvBuilderWithRequirements(EnvBuilder):
+
+    def __init__(self, bundle: RunnableConfigBundle):
+        super().__init__(system_site_packages=True, clear=False, with_pip=False)
+        self.bundle = bundle
+
+    def post_setup(self, context: SimpleNamespace) -> None:
+        requirements = self.bundle.requirements_file
+        if not requirements:
+            raise ValueError(f'Requirements file was not specified in {self.bundle.config_path}!')
+        elif not Path(requirements).exists():
+            raise ValueError(f'Requirements file {requirements} was not found!')
+        sys.stderr.write(f'Installing {requirements}...\n')
+        sys.stderr.flush()
+
+        args = [context.env_exe, '-m', 'ensurepip']
+        finished_process = self.run_and_dump(args, timeout=120)
+
+        # Install in the virtual environment
+        args = [context.env_exe, '-m', 'pip', 'install', '-U', '-r', requirements]
+        finished_process = self.run_and_dump(args, timeout=300)
+
+        if finished_process.returncode > 0:
+            sys.stderr.write('FAILED to install requirements!')
+            return
+        sys.stderr.write('done.\n')
+
+    def run_and_dump(self, args: List[str], timeout: int):
+        finished_process = run(args, cwd=self.bundle.config_directory, capture_output=False, timeout=timeout)
+        return finished_process
+
+
+def setup_virtual_environment(runnable: RunnableConfigBundle):
+    if not runnable.supports_virtual_environment or not runnable.requirements_file:
+        raise ValueError(f'{runnable.name} is not configured for virtual environment support!')
+    builder = EnvBuilderWithRequirements(bundle=runnable)
+    builder.create(Path(runnable.config_directory) / 'venv')
+

--- a/src/main/python/rlbot/utils/virtual_environment_management.py
+++ b/src/main/python/rlbot/utils/virtual_environment_management.py
@@ -42,7 +42,7 @@ class EnvBuilderWithRequirements(EnvBuilder):
 
 
 def setup_virtual_environment(runnable: RunnableConfigBundle):
-    if not runnable.supports_virtual_environment or not runnable.requirements_file:
+    if not runnable.use_virtual_environment or not runnable.requirements_file:
         raise ValueError(f'{runnable.name} is not configured for virtual environment support!')
     builder = EnvBuilderWithRequirements(bundle=runnable)
     builder.create(Path(runnable.config_directory) / 'venv')

--- a/src/main/python/rlbot/version.py
+++ b/src/main/python/rlbot/version.py
@@ -4,12 +4,12 @@
 # 3) we can import it into your module module
 # https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
 
-__version__ = '1.51.0'
+__version__ = '1.51.1'
 
 release_notes = {
-    '1.51.0': """
+    '1.51.1': """
     Adding support for standalone python bots, giving faster startup and more
-    intuitive development workflow.
+    intuitive development workflow. Also brings support for per-bot virtual environments.
     """,
     '1.50.0': """
     Changing the format of the ready message.

--- a/src/test/python/agents/standalone/requirements.txt
+++ b/src/test/python/agents/standalone/requirements.txt
@@ -1,0 +1,1 @@
+quicktracer==1.4.0

--- a/src/test/python/agents/standalone/standalone.cfg
+++ b/src/test/python/agents/standalone/standalone.cfg
@@ -4,3 +4,5 @@ python_file = standalone.py
 supports_standalone = True
 name = StandaloneBot
 maximum_tick_rate_preference = 120
+supports_venv = True
+requirements_file = requirements.txt

--- a/src/test/python/agents/standalone/standalone.cfg
+++ b/src/test/python/agents/standalone/standalone.cfg
@@ -4,5 +4,5 @@ python_file = standalone.py
 supports_standalone = True
 name = StandaloneBot
 maximum_tick_rate_preference = 120
-supports_venv = True
 requirements_file = requirements.txt
+use_virtual_environment = True

--- a/src/test/python/agents/standalone/standalone.py
+++ b/src/test/python/agents/standalone/standalone.py
@@ -1,6 +1,7 @@
+from queue import Empty
+
 from rlbot.agents.base_agent import SimpleControllerState
 from rlbot.agents.standalone.standalone_bot import StandaloneBot, run_bot
-
 from rlbot.utils.structures.game_data_struct import GameTickPacket
 
 
@@ -13,6 +14,13 @@ class StandaloneTest(StandaloneBot):
         controller_state.steer = -1 if int(game_tick_packet.game_info.seconds_elapsed) % 2 == 0 else 1
         self.renderer.draw_line_3d((0, 0, 50), (0, 0, 2000), self.renderer.orange())
         return controller_state
+
+    def initialize_agent(self):
+        try:
+            item = self.matchcomms.incoming_broadcast.get(block=False)
+            print(str(item))
+        except Empty:
+            print("Nothing on matchcomms")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
A standalone bot can have its own virtual environment with different package versions from other bots in the same match.
For this to work, the .cfg file needs all three of these:
```
[Locations]
supports_standalone = True
use_virtual_environment = True
requirements_file = requirements.txt
```

Before the match begins, the virtual environment will be created in a `venv` folder next to the bot cfg, and anything in the requirements file will be installed to it. When the bot is run, the venv will be used instead of the interpreter RLBot is using.

This will make it much easier for people to package / vend utility libraries because they can make breaking changes and individual bots can pin themselves to different versions and still play in the same match.

This slows down the startup process a bit, but it happens *before* we load up the match, so this does not put bots in danger of missing the first kickoff.