### PR TITLE
Socket manager for connecting directly to RLBot.exe from Python.

### DIFF
--- a/src/main/python/rlbot/matchconfig/loadout_config.py
+++ b/src/main/python/rlbot/matchconfig/loadout_config.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
 
+from flatbuffers import Builder
+from rlbot.messages.flat import LoadoutPaint, PlayerLoadout, Color as FlatColor
 from rlbot.utils.structures.start_match_structures import PlayerConfiguration
 from rlbot.utils.structures.start_match_structures import Color as ColorStruct
 
@@ -49,9 +51,39 @@ class LoadoutConfig:
             player_configuration.use_rgb_lookup = True
             self.secondary_color_lookup.write(player_configuration.secondary_color_lookup)
 
+    def write_to_flatbuffer(self, builder: Builder):
+        if self.paint_config:
+            paint_offset = self.paint_config.write_to_flatbuffer(builder)
+
+        if self.primary_color_lookup:
+            primary_color_offset = self.primary_color_lookup.write_to_flatbuffer(builder)
+        if self.secondary_color_lookup:
+            secondary_color_offset = self.secondary_color_lookup.write_to_flatbuffer(builder)
+
+        PlayerLoadout.PlayerLoadoutStart(builder)
+        PlayerLoadout.PlayerLoadoutAddTeamColorId(builder, self.team_color_id)
+        PlayerLoadout.PlayerLoadoutAddCustomColorId(builder, self.custom_color_id)
+        PlayerLoadout.PlayerLoadoutAddCarId(builder, self.car_id)
+        PlayerLoadout.PlayerLoadoutAddDecalId(builder, self.decal_id)
+        PlayerLoadout.PlayerLoadoutAddWheelsId(builder, self.wheels_id)
+        PlayerLoadout.PlayerLoadoutAddBoostId(builder, self.boost_id)
+        PlayerLoadout.PlayerLoadoutAddAntennaId(builder, self.antenna_id)
+        PlayerLoadout.PlayerLoadoutAddHatId(builder, self.hat_id)
+        PlayerLoadout.PlayerLoadoutAddPaintFinishId(builder, self.paint_finish_id)
+        PlayerLoadout.PlayerLoadoutAddCustomFinishId(builder, self.custom_finish_id)
+        PlayerLoadout.PlayerLoadoutAddEngineAudioId(builder, self.engine_audio_id)
+        PlayerLoadout.PlayerLoadoutAddTrailsId(builder, self.trails_id)
+        PlayerLoadout.PlayerLoadoutAddGoalExplosionId(builder, self.goal_explosion_id)
+        if self.paint_config:
+            PlayerLoadout.PlayerLoadoutAddLoadoutPaint(builder, paint_offset)
+        if self.primary_color_lookup:
+            PlayerLoadout.PlayerLoadoutAddPrimaryColorLookup(builder, primary_color_offset)
+        if self.secondary_color_lookup:
+            PlayerLoadout.PlayerLoadoutAddSecondaryColorLookup(builder, secondary_color_offset)
+        return PlayerLoadout.PlayerLoadoutEnd(builder)
+
     def __eq__(self, other):
         return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
 
 class LoadoutPaintConfig:
     def __init__(self):
@@ -74,6 +106,20 @@ class LoadoutPaintConfig:
         player_configuration.trails_paint_id = self.trails_paint_id
         player_configuration.goal_explosion_paint_id = self.goal_explosion_paint_id
 
+    def write_to_flatbuffer(self, builder: Builder):
+        paint = self
+        LoadoutPaint.LoadoutPaintStart(builder)
+        if paint:
+            LoadoutPaint.LoadoutPaintAddCarPaintId(builder, paint.car_paint_id)
+            LoadoutPaint.LoadoutPaintAddDecalPaintId(builder, paint.decal_paint_id)
+            LoadoutPaint.LoadoutPaintAddWheelsPaintId(builder, paint.wheels_paint_id)
+            LoadoutPaint.LoadoutPaintAddBoostPaintId(builder, paint.boost_paint_id)
+            LoadoutPaint.LoadoutPaintAddAntennaPaintId(builder, paint.antenna_paint_id)
+            LoadoutPaint.LoadoutPaintAddHatPaintId(builder, paint.hat_paint_id)
+            LoadoutPaint.LoadoutPaintAddTrailsPaintId(builder, paint.trails_paint_id)
+            LoadoutPaint.LoadoutPaintAddGoalExplosionPaintId(builder, paint.goal_explosion_paint_id)
+        return LoadoutPaint.LoadoutPaintEnd(builder)
+
     def __eq__(self, other):
         return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
@@ -90,3 +136,14 @@ class Color:
         color.g = self.green
         color.b = self.blue
         color.a = self.alpha
+
+    def write_to_flatbuffer(self, builder: Builder):
+        FlatColor.ColorStart(builder)
+        FlatColor.ColorAddR(builder, self.red)
+        FlatColor.ColorAddG(builder, self.green)
+        FlatColor.ColorAddB(builder, self.blue)
+        FlatColor.ColorAddA(builder, self.alpha)
+        return FlatColor.ColorEnd(builder)
+
+
+

--- a/src/main/python/rlbot/socket/socket_manager.py
+++ b/src/main/python/rlbot/socket/socket_manager.py
@@ -1,0 +1,151 @@
+from enum import IntEnum
+from socket import socket
+from typing import List, Callable
+
+from flatbuffers.builder import Builder
+from rlbot.agents.base_agent import SimpleControllerState
+from rlbot.matchconfig.match_config import MatchConfig
+from rlbot.messages.flat import ReadyMessage
+from rlbot.messages.flat.BallPrediction import BallPrediction
+from rlbot.messages.flat.FieldInfo import FieldInfo
+from rlbot.messages.flat.GameMessage import GameMessage
+from rlbot.messages.flat.GameTickPacket import GameTickPacket
+from rlbot.messages.flat.MatchSettings import MatchSettings
+from rlbot.messages.flat.MessagePacket import MessagePacket
+from rlbot.messages.flat.PlayerInputChange import PlayerInputChange
+from rlbot.messages.flat.PlayerSpectate import PlayerSpectate
+from rlbot.messages.flat.PlayerStatEvent import PlayerStatEvent
+from rlbot.messages.flat.QuickChat import QuickChat
+from rlbot.utils.logging_utils import get_logger
+
+
+class SocketDataType(IntEnum):
+    GAME_TICK_PACKET = 1
+    FIELD_INFO = 2
+    MATCH_SETTINGS = 3
+    PLAYER_INPUT = 4
+    ACTOR_MAPPING = 5
+    COMPUTER_ID = 6
+    DESIRED_GAME_STATE = 7
+    RENDER_GROUP = 8
+    QUICK_CHAT = 9
+    BALL_PREDICTION = 10
+    READY_MESSAGE = 11
+    MESSAGE_PACKET = 12
+
+
+def int_to_bytes(val: int) -> bytes:
+    return val.to_bytes(2, byteorder='big')
+
+
+def int_from_bytes(bytes: bytes) -> int:
+    return int.from_bytes(bytes, 'big')
+
+
+class SocketMessage:
+    def __init__(self, type: SocketDataType, data: bytes):
+        self.type = type
+        self.data = data
+
+
+def read_from_socket(s: socket) -> SocketMessage:
+    type_int = int_from_bytes(s.recv(2))
+    data_type = SocketDataType(type_int)
+    size = int_from_bytes(s.recv(2))
+    data = s.recv(size)
+    return SocketMessage(data_type, data)
+
+
+class SocketRelay:
+    def __init__(self):
+        self.logger = get_logger('socket_man')
+        self.socket = socket()
+        self.is_connected = False
+        self._should_continue = True
+        self.packet_handlers: List[Callable[[GameTickPacket], None]] = []
+        self.field_info_handlers: List[Callable[[FieldInfo], None]] = []
+        self.match_settings_handlers: List[Callable[[MatchSettings], None]] = []
+        self.quick_chat_handlers: List[Callable[[QuickChat], None]] = []
+        self.ball_prediction_handlers: List[Callable[[BallPrediction], None]] = []
+        self.player_input_change_handlers: List[Callable[[PlayerInputChange, float, int], None]] = []
+        self.player_stat_handlers: List[Callable[[PlayerStatEvent, float, int], None]] = []
+        self.player_spectate_handlers: List[Callable[[PlayerSpectate, float, int], None]] = []
+
+    def send_flatbuffer(self, builder: Builder, data_type: SocketDataType):
+        flatbuffer_bytes = builder.Output()
+        size = len(flatbuffer_bytes)
+        message = int_to_bytes(data_type) + int_to_bytes(size) + flatbuffer_bytes
+        self.socket.sendall(message)
+
+    def send_player_input(self, player_index: int, input: SimpleControllerState):
+        builder = input.to_flatbuffer(player_index)
+        self.send_flatbuffer(builder, SocketDataType.PLAYER_INPUT)
+
+    def send_match_config(self, mc: MatchConfig):
+        builder = mc.create_flatbuffer()
+        self.send_flatbuffer(builder, SocketDataType.MATCH_SETTINGS)
+
+    def connect_and_run(self, wants_quick_chat, wants_game_messages, wants_ball_predictions):
+
+        self.socket.connect(('127.0.0.1', 23234))
+        self.is_connected = True
+        self.logger.info("Connected!")
+
+        builder = Builder(50)
+        ReadyMessage.ReadyMessageStart(builder)
+        ReadyMessage.ReadyMessageAddWantsBallPredictions(builder, wants_ball_predictions)
+        ReadyMessage.ReadyMessageAddWantsQuickChat(builder, wants_quick_chat)
+        ReadyMessage.ReadyMessageAddWantsGameMessages(builder, wants_game_messages)
+        offset = ReadyMessage.ReadyMessageEnd(builder)
+        builder.Finish(offset)
+        self.send_flatbuffer(builder, SocketDataType.READY_MESSAGE)
+
+        while self._should_continue:
+            incoming_message = read_from_socket(self.socket)
+            if incoming_message.type == SocketDataType.GAME_TICK_PACKET and len(self.packet_handlers) > 0:
+                packet = GameTickPacket.GetRootAsGameTickPacket(incoming_message.data, 0)
+                for handler in self.packet_handlers:
+                    handler(packet)
+            elif incoming_message.type == SocketDataType.FIELD_INFO and len(self.field_info_handlers) > 0:
+                field_info = FieldInfo.GetRootAsFieldInfo(incoming_message.data, 0)
+                for handler in self.field_info_handlers:
+                    handler(field_info)
+            elif incoming_message.type == SocketDataType.MATCH_SETTINGS and len(self.match_settings_handlers) > 0:
+                match_settings = MatchSettings.GetRootAsMatchSettings(incoming_message.data, 0)
+                for handler in self.match_settings_handlers:
+                    handler(match_settings)
+            elif incoming_message.type == SocketDataType.QUICK_CHAT and len(self.quick_chat_handlers) > 0:
+                quick_chat = QuickChat.GetRootAsQuickChat(incoming_message.data, 0)
+                for handler in self.quick_chat_handlers:
+                    handler(quick_chat)
+            elif incoming_message.type == SocketDataType.BALL_PREDICTION and len(self.ball_prediction_handlers) > 0:
+                ball_prediction = BallPrediction.GetRootAsBallPrediction(incoming_message.data, 0)
+                for handler in self.ball_prediction_handlers:
+                    handler(ball_prediction)
+            elif incoming_message.type == SocketDataType.MESSAGE_PACKET:
+                if len(self.player_stat_handlers) > 0 or len(self.player_input_change_handlers) > 0 or len(
+                        self.player_spectate_handlers) > 0:
+                    msg_packet = MessagePacket.GetRootAsMessagePacket(incoming_message.data, 0)
+                    for i in range(msg_packet.MessagesLength()):
+                        msg = msg_packet.Messages(i)
+                        msg_type = msg.MessageType()
+                        if msg_type == GameMessage.PlayerSpectate and len(self.player_spectate_handlers) > 0:
+                            spectate = PlayerSpectate()
+                            spectate.Init(msg.Message().Bytes, msg.Message().Pos)
+                            for handler in self.player_spectate_handlers:
+                                handler(spectate, msg_packet.GameSeconds(), msg_packet.FrameNum())
+                        elif msg_type == GameMessage.PlayerStatEvent and len(self.player_stat_handlers) > 0:
+                            stat_event = PlayerStatEvent()
+                            stat_event.Init(msg.Message().Bytes, msg.Message().Pos)
+                            for handler in self.player_stat_handlers:
+                                handler(stat_event, msg_packet.GameSeconds(), msg_packet.FrameNum())
+                        elif msg_type == GameMessage.PlayerInputChange and len(
+                                self.player_input_change_handlers) > 0:
+                            input_change = PlayerInputChange()
+                            input_change.Init(msg.Message().Bytes, msg.Message().Pos)
+                            for handler in self.player_input_change_handlers:
+                                handler(input_change, msg_packet.GameSeconds(), msg_packet.FrameNum())
+        self.socket.close()
+
+    def disconnect(self):
+        self._should_continue = False

--- a/src/main/python/rlbot/version.py
+++ b/src/main/python/rlbot/version.py
@@ -4,9 +4,13 @@
 # 3) we can import it into your module module
 # https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
 
-__version__ = '1.51.3'
+__version__ = '1.52.0'
 
 release_notes = {
+    '1.52.0': """
+    Adding a socket management utility in Python to help people connect directly to
+    RLBot.exe and write interesting scripts.
+    """,
     '1.51.3': """
     Adding support for standalone python bots, giving faster startup and more
     intuitive development workflow. Also brings support for per-bot virtual environments.

--- a/src/test/python/agents/script/socket_match_starter.py
+++ b/src/test/python/agents/script/socket_match_starter.py
@@ -1,6 +1,4 @@
 from pathlib import Path
-from threading import Thread
-from time import sleep
 
 from rlbot.matchconfig.conversions import read_match_config_from_file
 from rlbot.socket.socket_manager import SocketRelay
@@ -11,17 +9,15 @@ class SampleScript:
     def __init__(self):
         self.socket_relay = SocketRelay()
 
-    def run(self):
-        thread = Thread(target=self.socket_relay.connect_and_run, args=(True, True, True))
-        thread.start()
-        while not self.socket_relay.is_connected:
-            print('Waiting for connection...')
-            sleep(1)
+    def start_match(self):
         match_config = read_match_config_from_file(Path(__file__).parent.parent.parent.parent.parent.parent / 'rlbot.cfg')
         print("Sending match config")
         self.socket_relay.send_match_config(match_config)
         self.socket_relay.disconnect()
-        thread.join()
+
+    def run(self):
+        self.socket_relay.on_connect_handlers.append(self.start_match)
+        self.socket_relay.connect_and_run(wants_quick_chat=False, wants_game_messages=False, wants_ball_predictions=False)
 
 
 # You can use this __name__ == '__main__' thing to ensure that the script doesn't start accidentally if you

--- a/src/test/python/agents/script/socket_match_starter.py
+++ b/src/test/python/agents/script/socket_match_starter.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+from threading import Thread
+from time import sleep
+
+from rlbot.matchconfig.conversions import read_match_config_from_file
+from rlbot.socket.socket_manager import SocketRelay
+
+
+class SampleScript:
+
+    def __init__(self):
+        self.socket_relay = SocketRelay()
+
+    def run(self):
+        thread = Thread(target=self.socket_relay.connect_and_run, args=(True, True, True))
+        thread.start()
+        while not self.socket_relay.is_connected:
+            print('Waiting for connection...')
+            sleep(1)
+        match_config = read_match_config_from_file(Path(__file__).parent.parent.parent.parent.parent.parent / 'rlbot.cfg')
+        print("Sending match config")
+        self.socket_relay.send_match_config(match_config)
+        self.socket_relay.disconnect()
+        thread.join()
+
+
+# You can use this __name__ == '__main__' thing to ensure that the script doesn't start accidentally if you
+# merely reference its module from somewhere
+if __name__ == '__main__':
+    print("Start match script starting...")
+    script = SampleScript()
+    script.run()

--- a/src/test/python/agents/script/socket_script.py
+++ b/src/test/python/agents/script/socket_script.py
@@ -1,0 +1,40 @@
+from rlbot.agents.base_agent import SimpleControllerState
+from rlbot.messages.flat.PlayerInputChange import PlayerInputChange
+from rlbot.messages.flat.PlayerSpectate import PlayerSpectate
+from rlbot.messages.flat.PlayerStatEvent import PlayerStatEvent
+from rlbot.socket.socket_manager import SocketRelay
+
+
+class SampleScript:
+
+    def __init__(self):
+        self.socket_relay = SocketRelay()
+
+    def handle_spectate(self, spectate: PlayerSpectate, seconds: float, frame_num: int):
+        print(f'Spectating player index {spectate.PlayerIndex()}')
+        # Make the bot jump whenever we start spectating them >:)
+        controls = SimpleControllerState()
+        controls.jump = True
+        self.socket_relay.send_player_input(spectate.PlayerIndex(), controls)
+
+    def handle_stat(self, stat: PlayerStatEvent, seconds: float, frame_num: int):
+        stat_value = stat.StatType().decode('utf-8')
+        print(f'Stat player index {stat.PlayerIndex()}: {stat_value}')
+
+    def input_change(self, change: PlayerInputChange, seconds: float, frame_num: int):
+        if change.ControllerState().Jump():
+            print(f'Player index {change.PlayerIndex()} is jumping!')
+
+    def run(self):
+        self.socket_relay.player_spectate_handlers.append(self.handle_spectate)
+        self.socket_relay.player_stat_handlers.append(self.handle_stat)
+        self.socket_relay.player_input_change_handlers.append(self.input_change)
+        self.socket_relay.connect_and_run(wants_quick_chat=True, wants_game_messages=True, wants_ball_predictions=True)
+
+
+# You can use this __name__ == '__main__' thing to ensure that the script doesn't start accidentally if you
+# merely reference its module from somewhere
+if __name__ == '__main__':
+    print("Socket script starting...")
+    script = SampleScript()
+    script.run()


### PR DESCRIPTION
Now that sockets is out, it's possible to bypass the dll and have Python talk directly with RLBot.exe on the socket. I've written a helper class to make this easier.

This is cool because it's the first time certain data is readily available:
- Player spectate events: When a particular player is spectated in-game, their index will be emitted
- Player input changes: When a player (bot or human) moves their controls in any way, the data is emitted
- Player stat events: Any time something happens, e.g. ball centered, hat trick, demolition, etc, an event is emitted

It can also be used to send player inputs and match starts. I haven't gotten around to implementing rendering, state setting, or quick chat, but that can be done later.

Check out the test scripts in this PR to see how it looks to an end user.