### PR TITLE
Fix error when starting a match with a human & rename Neon_Fields to NeonFields

### DIFF
--- a/src/main/flatbuffers/rlbot.fbs
+++ b/src/main/flatbuffers/rlbot.fbs
@@ -636,7 +636,7 @@ enum GameMap : byte {
   RivalsArena,
   Farmstead_Night,
   SaltyShores_Night,
-  Neon_Fields
+  NeonFields
 }
 
 enum MatchLength : byte {

--- a/src/main/python/rlbot/matchconfig/match_config.py
+++ b/src/main/python/rlbot/matchconfig/match_config.py
@@ -78,9 +78,9 @@ class PlayerConfig:
 
     def write_to_flatbuffer(self, builder: Builder):
         name = builder.CreateString(self.name)
-        loadout = self.loadout_config.write_to_flatbuffer(builder)
 
         if self.bot:
+            loadout = self.loadout_config.write_to_flatbuffer(builder)
             if self.rlbot_controlled:
                 variety = PlayerClass.RLBotPlayer
                 RLBotPlayer.RLBotPlayerStart(builder)
@@ -91,6 +91,7 @@ class PlayerConfig:
                 PsyonixBotPlayer.PsyonixBotPlayerAddBotSkill(builder, self.bot_skill)
                 player = PsyonixBotPlayer.PsyonixBotPlayerEnd(builder)
         else:
+            loadout = LoadoutConfig().write_to_flatbuffer(builder)
             variety = PlayerClass.HumanPlayer
             HumanPlayer.HumanPlayerStart(builder)
             player = HumanPlayer.HumanPlayerEnd(builder)

--- a/src/main/python/rlbot/parsing/match_settings_config_parser.py
+++ b/src/main/python/rlbot/parsing/match_settings_config_parser.py
@@ -90,7 +90,7 @@ game_map_dict = {
     "RivalsArena": "cs_hw_p",
     "Farmstead_Night": "Farm_Night_P",
     "SaltyShores_Night": "beach_night_p",
-    "Neon_Fields": "music_p",
+    "NeonFields": "music_p",
 }
 
 map_types = list(game_map_dict.keys())

--- a/src/main/python/rlbot/version.py
+++ b/src/main/python/rlbot/version.py
@@ -4,12 +4,12 @@
 # 3) we can import it into your module module
 # https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
 
-__version__ = '1.53.0'
+__version__ = '1.53.1'
 
 release_notes = {
-    '1.53.0': """
+    '1.53.1': """
     Making it possible to maintain the map list in the open source portion of RLBot,
-    and adding support for Neon_Fields.
+    and adding support for NeonFields.
     """,
     '1.52.0': """
     Adding a socket management utility in Python to help people connect directly to


### PR DESCRIPTION
- currently when you try to start a match with a human it errors because humans don't have a loadout config, this should fix it
- renamed Neon_Fields to NeonFields because that's what I named it in the GUI (sorry), I think it follows the naming convention better (underscores are mostly for alternative versions)