### PR TITLE
Fixing issue where bots were sent their original name rather than deduped name

### DIFF
--- a/rlbot.cfg
+++ b/rlbot.cfg
@@ -16,7 +16,7 @@ Team Orange Name = Orange
 
 [Match Configuration]
 # Number of bots/players which will be spawned.  We support up to max 64.
-num_participants = 6
+num_participants = 2
 # What game mode the game should load.
 # Accepted values are "Soccer", "Hoops", "Dropshot", "Hockey", "Rumble", "Heatseeker"
 game_mode = Soccer
@@ -59,8 +59,8 @@ Respawn Time = 1 Second
 # Only total_num_participants config files will be read!
 # Everything needs a config, even players and default bots.
 # We still set loadouts and names from config!
-participant_config_0 = src/test/python/agents/hivemind/config.cfg
-participant_config_1 = src/test/python/agents/hivemind/config.cfg
+participant_config_0 = src/test/python/agents/atba/atba.cfg
+participant_config_1 = src/test/python/agents/atba/atba.cfg
 participant_config_2 = src/test/python/agents/hivemind/config.cfg
 participant_config_3 = src/test/python/agents/hivemind/config.cfg
 participant_config_4 = src/test/python/agents/hivemind/config.cfg

--- a/src/main/python/rlbot/matchconfig/match_config.py
+++ b/src/main/python/rlbot/matchconfig/match_config.py
@@ -44,6 +44,7 @@ class PlayerConfig:
         self.bot_skill: float = None
         self.human_index: int = None
         self.name: str = None
+        self.deduped_name: str = None
         self.team: int = None
         self.config_path: str = None  # Required only if rlbot_controlled is true
         self.loadout_config: LoadoutConfig = None
@@ -65,11 +66,12 @@ class PlayerConfig:
         return bot_config
 
     def write(self, player_configuration: PlayerConfiguration, name_dict: dict):
+        self.deduped_name = get_sanitized_bot_name(name_dict, self.name)
         player_configuration.bot = self.bot
         player_configuration.rlbot_controlled = self.rlbot_controlled
         player_configuration.bot_skill = self.bot_skill or 0
         player_configuration.human_index = self.human_index or 0
-        player_configuration.name = get_sanitized_bot_name(name_dict, self.name)
+        player_configuration.name = self.deduped_name
         player_configuration.team = self.team
         player_configuration.spawn_id = self.spawn_id
 
@@ -77,7 +79,8 @@ class PlayerConfig:
             self.loadout_config.write(player_configuration)
 
     def write_to_flatbuffer(self, builder: Builder, name_dict: dict):
-        name = builder.CreateString(get_sanitized_bot_name(name_dict, self.name))
+        self.deduped_name = get_sanitized_bot_name(name_dict, self.name)
+        name = builder.CreateString(self.deduped_name)
 
         if self.loadout_config:
             loadout = self.loadout_config.write_to_flatbuffer(builder)

--- a/src/main/python/rlbot/setup_manager.py
+++ b/src/main/python/rlbot/setup_manager.py
@@ -452,7 +452,7 @@ class SetupManager:
 
             if participant_index not in self.bot_processes:
                 bundle = get_bot_config_bundle(player_config.config_path)
-                name = str(self.match_config.player_configs[i].name)
+                name = str(self.match_config.player_configs[i].deduped_name)
                 if bundle.supports_standalone:
                     executable = sys.executable
                     if bundle.use_virtual_environment:

--- a/src/main/python/rlbot/version.py
+++ b/src/main/python/rlbot/version.py
@@ -4,10 +4,10 @@
 # 3) we can import it into your module module
 # https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
 
-__version__ = '1.55.5'
+__version__ = '1.55.6'
 
 release_notes = {
-    '1.55.5': """
+    '1.55.6': """
     Using sockets for match start, lifting the restrictions on max players when using flatbuffers,
     and sending a game tick packet immediately upon socket connection to fix some bugs.
     """,

--- a/src/test/python/agents/atba/atba.py
+++ b/src/test/python/agents/atba/atba.py
@@ -4,6 +4,7 @@ from random import random
 from typing import List
 
 from rlbot.agents.base_agent import BaseAgent, BOT_CONFIG_AGENT_HEADER, SimpleControllerState
+from rlbot.matchconfig.match_config import MatchConfig
 from rlbot.messages.flat.RumbleOption import RumbleOption
 from rlbot.parsing.custom_config import ConfigObject
 from rlbot.utils.game_state_util import GameState, BoostState, BallState, CarState, GameInfoState, Physics, Vector3
@@ -76,6 +77,9 @@ class Atba(BaseAgent):
         self.state_listener = StateListener(index)
         self.sequence: Sequence = None
         self.prev_seconds_elapsed = 0
+
+    def init_match_config(self, match_config: MatchConfig):
+        self.logger.info(match_config.player_configs[self.index].name)
 
     def get_output(self, game_tick_packet: GameTickPacket) -> SimpleControllerState:
         controller_state = SimpleControllerState()


### PR DESCRIPTION
This is intended to fix https://github.com/RLBot/RLBot/issues/546

Bots in a match often have names like `SomeBot` and `SomeBot (2)` if there are duplicates. In the past we have always told the bot their name is `SomeBot (2)` if applicable, and bot logic has adapted to this, so we need to keep it that way. A recent change broke it, this fix will put it back.

It's good in general to have `SomeBot (2)` because the game tick packet includes bot names in some places, e.g. ball touch, and this will make it match.

If you're making a python bot and want the original name, you can do something like this:

```python
# This overrides a method in base agent and will get called automatically
def init_match_config(self, match_config: MatchConfig):
        self.logger.info(match_config.player_configs[self.index].name)
```