### PR TITLE
Give scripts access to matchcomms

### DIFF
--- a/src/main/python/rlbot/agents/base_script.py
+++ b/src/main/python/rlbot/agents/base_script.py
@@ -36,10 +36,15 @@ class BaseScript(RLBotRunnable):
         # Get matchcomms root if provided as a command line argument.
         try:
             pos = sys.argv.index("--matchcomms-url")
-            potential_url = sys.argv[pos + 1]
-            self.matchcomms_root = urlparse(potential_url)  # Not sure what to do if this is not a valid url
+            potential_url = urlparse(sys.argv[pos + 1])
         except (ValueError, IndexError):
+            # Missing the command line argument.
             pass
+        else:
+            if potential_url.scheme == "ws" and potential_url.netloc:
+                self.matchcomms_root = potential_url
+            else:
+                raise ValueError("The matchcomms url is invalid")
 
     def get_game_tick_packet(self):
         """Gets the latest game tick packet immediately, without blocking."""

--- a/src/main/python/rlbot/setup_manager.py
+++ b/src/main/python/rlbot/setup_manager.py
@@ -498,8 +498,14 @@ class SetupManager:
             if script_config_bundle.use_virtual_environment:
                 executable = str(Path(script_config_bundle.config_directory) / 'venv' / 'Scripts' / 'python.exe')
 
-            process = subprocess.Popen([executable, script_config_bundle.script_file],
-                                       cwd=Path(script_config_bundle.config_directory).parent)
+            process = subprocess.Popen(
+                [
+                    executable,
+                    script_config_bundle.script_file, 
+                    '--matchcomms-url', self.matchcomms_server.root_url.geturl()
+                ],
+                cwd=Path(script_config_bundle.config_directory).parent
+            )
             self.logger.info(f"Started script with pid {process.pid} using {process.args}")
             self.script_processes[process.pid] = process
             scripts_started += 1

--- a/src/main/python/rlbot/setup_manager.py
+++ b/src/main/python/rlbot/setup_manager.py
@@ -409,8 +409,8 @@ class SetupManager:
 
     def launch_bot_process_helper(self, early_starters_only=False, match_config: MatchConfig = None):
         # Start matchcomms here as it's only required for the bots.
-        self.kill_matchcomms_server()
-        self.matchcomms_server = launch_matchcomms_server()
+        if not self.matchcomms_server:
+            self.matchcomms_server = launch_matchcomms_server()
         self.bot_processes = {ind: proc for ind, proc in self.bot_processes.items() if proc.is_alive()}
 
         num_started = 0


### PR DESCRIPTION
- Pass the matchcomms URL as a command line argument to scripts
- Read command line arguments for matchcomms URL

Still need to do:
- Figure out if we need to close matchcomms when script terminates (and how to close it)
- Possible bug: https://discord.com/channels/348658686962696195/423167304956903428/813503008796049469
- Fix crashing during match stop (might not be directly related, but I did encounter it a lot during testing)
- Give Hiveminds access to matchcomms