### PR TITLE
Add team-only matchcomms (and catch an exception in process_configuration.py)

### DIFF
--- a/src/main/python/rlbot/agents/base_agent.py
+++ b/src/main/python/rlbot/agents/base_agent.py
@@ -183,7 +183,7 @@ class BaseAgent(RLBotRunnable):
                              "ignore matchcomms in your case then go ahead and wrap your matchcomms access "
                              "in a try-except, or do a check first for whether matchcomms_root is None.")
         if self._matchcomms is None:
-            self._matchcomms = MatchcommsClient(self.matchcomms_root)
+            self._matchcomms = MatchcommsClient(self.matchcomms_root, self.team)
         return self._matchcomms  # note: _matchcomms.close() is called by the bot_manager.
 
     def load_config(self, config_object_header):

--- a/src/main/python/rlbot/matchcomms/client.py
+++ b/src/main/python/rlbot/matchcomms/client.py
@@ -68,7 +68,6 @@ class MatchcommsClient:
         self.thread.join(1)
         assert not self.thread.is_alive()
 
-
 async def read_into_queue(websocket: WebSocketClientProtocol, incoming: Queue, team):
     async for message in websocket:
         try:
@@ -91,9 +90,12 @@ async def send_from_queue(websocket: WebSocketClientProtocol, outgoing: Queue, t
             await asyncio.sleep(0.01)
 
         obj = outgoing.get_nowait()
+        # Be verbose if we are overriding the team attr
+        if "team" in obj and obj["team"] != team:
+            print("Overriding the 'team' key in your match communication object!")
         # if we aren't a script, add our team to the packet so that team-only matchcomms can work
-        if team is not None:
-            obj["team"] = team
+        obj["team"] = team
+
         try:
             json_str = json.dumps(obj) # Serialize the object that was put on the outgoing queue
         except TypeError:

--- a/src/main/python/rlbot/utils/process_configuration.py
+++ b/src/main/python/rlbot/utils/process_configuration.py
@@ -99,7 +99,7 @@ def is_process_running(program, scriptname, required_args: Set[str]) -> Tuple[bo
             p = process.name()
             if program in p or scriptname in p:
                 matching_processes.append(process)
-        except psutil.NoSuchProcess:
+        except (psutil.NoSuchProcess, psutil.AccessDenie):
             continue
     # If matching processes were found, check for correct arguments.
     if len(matching_processes) != 0:

--- a/src/main/python/rlbot/utils/process_configuration.py
+++ b/src/main/python/rlbot/utils/process_configuration.py
@@ -99,7 +99,7 @@ def is_process_running(program, scriptname, required_args: Set[str]) -> Tuple[bo
             p = process.name()
             if program in p or scriptname in p:
                 matching_processes.append(process)
-        except (psutil.NoSuchProcess, psutil.AccessDenie):
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
             continue
     # If matching processes were found, check for correct arguments.
     if len(matching_processes) != 0:


### PR DESCRIPTION
How team-only matchcomms work:
- **_NOTE:_** This only works in Python.
- `rlbot.matchcomms.client.MatchcommsClient` automatically adds `team` to the sent packets.
- This doesn't break anything, unless you are sending a packet where `team` is the team you are not on, in which case the client will silently change it to your own team.
- If you would like to send a team-only matchcomm, add `'team_only': True` to your packet. If it is `False` or ommitted everybody can see it.
- Scripts can see all matchcomms, even team-only ones, and the ones they send are visible to everybody.
- It is possible to spoof this by bypassing the client entirely. See [this Discord conversation](https://discord.com/channels/348658686962696195/423167304956903428/821455192292982805) for more information on this.

I also added a catch in `process_configuration.py` that came up while I was working on this.

I'm sure I forgot something. Tell me if I did and I will fix it.