### PR TITLE
Add launcher_preference attribute to init

### DIFF
--- a/src/main/python/rlbot/setup_manager.py
+++ b/src/main/python/rlbot/setup_manager.py
@@ -153,6 +153,7 @@ class SetupManager:
         self.bot_reload_requests = []
         self.agent_metadata_map: Dict[int, AgentMetadata] = {}
         self.match_config: MatchConfig = None
+        self.launcher_preference = None
         self.rlbot_gateway_process = None
         self.matchcomms_server: MatchcommsServerThread = None
         self.early_start_seconds = 0


### PR DESCRIPTION
Running RLBot through the `setup_manager_context()` results in an exception
```
  File "D:\MyThings\Programming\RLBot\AutoLeague2\autoleague\match_runner.py", line 25, in run_match
    with setup_manager_context() as setup_manager:
  File "C:\Users\nicoesterby\AppData\Local\RLBotGUIX\Python37\lib\contextlib.py", line 112, in __enter__
    return next(self.gen)
  File "C:\Users\nicoesterby\AppData\Local\RLBotGUIX\venv\lib\site-packages\rlbot\setup_manager.py", line 97, in setup_manager_context
    setup_manager.connect_to_game()
  File "C:\Users\nicoesterby\AppData\Local\RLBotGUIX\venv\lib\site-packages\rlbot\setup_manager.py", line 204, in connect_to_game
    pref = launcher_preference or self.launcher_preference or DEFAULT_LAUNCHER_PREFERENCE
AttributeError: 'SetupManager' object has no attribute 'launcher_preference'
```

The SetupManager's `self.launcher_preference` is undefined when `load_config()` is not called before `connect_to_game()`.

This small fix should do the trick.