### PR TITLE
Add launcher preference option to setup manager context

### DIFF
--- a/src/main/python/rlbot/setup_manager.py
+++ b/src/main/python/rlbot/setup_manager.py
@@ -83,7 +83,7 @@ DEFAULT_LAUNCHER_PREFERENCE = RocketLeagueLauncherPreference(RocketLeagueLaunche
 
 
 @contextmanager
-def setup_manager_context():
+def setup_manager_context(launcher_preference: RocketLeagueLauncherPreference = None):
     """
     Creates a initialized context manager which shuts down at the end of the
     `with` block.
@@ -94,7 +94,7 @@ def setup_manager_context():
     ...     # ... Run match
     """
     setup_manager = SetupManager()
-    setup_manager.connect_to_game()
+    setup_manager.connect_to_game(launcher_preference)
     try:
         yield setup_manager
     except Exception as e:


### PR DESCRIPTION
My league play keeps starting up Epic and then Steam. The problem is that I use the `setup_manager_context()` which tries to connect to the game immediately. This PR adds an optional argument to `setup_manager_context()` with launcher preference.