### PR TITLE
fixed unhandled exception when doing epic startup trick

### DIFF
--- a/src/main/python/rlbot/utils/process_configuration.py
+++ b/src/main/python/rlbot/utils/process_configuration.py
@@ -116,8 +116,12 @@ def is_process_running(program, scriptname, required_args: Set[str]) -> Tuple[bo
                     return True, process
             except psutil.AccessDenied:
                 print(f"Access denied when trying to look at cmdline of {process}!")
-        # If we didn't return yet it means all matching programs were skipped.
-        raise WrongProcessArgs(f"{program} is not running with required arguments: {required_args}!")
+            except psutil.NoSuchProcess:
+                # process died whilst we were looking at it, so pretend we found none, it will get handles another time
+                break
+        else:
+            # If we didn't return yet it means all matching programs were skipped.
+            raise WrongProcessArgs(f"{program} is not running with required arguments: {required_args}!")
     # No matching processes.
     return False, None
 

--- a/src/main/python/rlbot/utils/process_configuration.py
+++ b/src/main/python/rlbot/utils/process_configuration.py
@@ -103,6 +103,7 @@ def is_process_running(program, scriptname, required_args: Set[str]) -> Tuple[bo
             continue
     # If matching processes were found, check for correct arguments.
     if len(matching_processes) != 0:
+        mismatch_found = False
         for process in matching_processes:
             try:
                 args = process.cmdline()[1:]
@@ -114,12 +115,13 @@ def is_process_running(program, scriptname, required_args: Set[str]) -> Tuple[bo
                 else:
                     # If this process has not been skipped, it matches all arguments.
                     return True, process
+                mismatch_found = True
             except psutil.AccessDenied:
                 print(f"Access denied when trying to look at cmdline of {process}!")
             except psutil.NoSuchProcess:
                 # process died whilst we were looking at it, so pretend we found none, it will get handles another time
-                break
-        else:
+                pass
+        if mismatch_found:
             # If we didn't return yet it means all matching programs were skipped.
             raise WrongProcessArgs(f"{program} is not running with required arguments: {required_args}!")
     # No matching processes.


### PR DESCRIPTION
psutil.NoSuchProcess was not handled for one code path during launch_with_epic_login_trick which would lead to it falling back to trying to start the old way, which means it would just end up with a RL without the rlbot flags.