### PR TITLE
Fix continue and spawn bug

### DIFF
--- a/src/main/python/rlbot/utils/packetanalysis/valid_packet_detector.py
+++ b/src/main/python/rlbot/utils/packetanalysis/valid_packet_detector.py
@@ -35,7 +35,7 @@ class ValidPacketDetector:
                     except KeyError:
                         pass
 
-                if len(spawn_ids) == 0 and self.expected_count == packet.PlayersLength():
+                if len(spawn_ids) == 0 and self.expected_count <= packet.PlayersLength():
                     self.logger.info('Packets are looking good, all spawn ids accounted for!')
                     return
                 elif i > 4:


### PR DESCRIPTION
This ONE SIMPLE TRICK fixes bot levitation on start!

You can trigger the bug in RLBot right now by:
Starting a match with no human and any number of bots
Join the game after launch
Using Continue and Spawn to start a new match

The bots will levitate into the air until you spectate the match, at which point you can rejoin (or you can wait out the built-in timer)

So basically, no more LAN match weirdness. I hope the single operator change explains itself. This MAY cause unintended side effects, but it's the easiest patch.

Permanent fix (idk how to do this):
Make `expected_count` and `PlayersLength()` somehow only account for bots - basically, just ignore the humans. Any actual issues that might stem from this will be edge cases where humans spawn in before bots and there are a lot of humans. Bots should still spawn in, it will just be a fraction of a second later. I can't see what could go wrong! 🥴