### PR TITLE
Fix for "Trouble with epic launch: 'NoneType' object has no attribute 'kill'" error

### DIFF
--- a/src/main/python/rlbot/gamelaunch/epic_launch.py
+++ b/src/main/python/rlbot/gamelaunch/epic_launch.py
@@ -109,7 +109,6 @@ def launch_with_epic_login_trick(ideal_args: List[str]) -> bool:
             time.sleep(1)
             logger.info("Waiting for Rocket League args...")
 
-        rl_running, process = is_process_running('RocketLeague.exe', 'RocketLeague.exe', set())
         process.kill()
         modified_args = ideal_args + all_args
         logger.info(f"Killed old rocket league, reopening with {modified_args}")

--- a/src/main/python/rlbot/gamelaunch/epic_launch.py
+++ b/src/main/python/rlbot/gamelaunch/epic_launch.py
@@ -12,7 +12,7 @@ from time import sleep
 from typing import Optional, List, Union
 
 from rlbot.utils.logging_utils import get_logger, DEFAULT_LOGGER
-from rlbot.utils.process_configuration import is_process_running
+from rlbot.utils.process_configuration import get_process
 
 
 def launch_with_epic_simple(ideal_args: List[str]) -> bool:
@@ -55,8 +55,8 @@ def args_contain_auth_info(args: List[str]) -> bool:
     return True in ["AUTH_LOGIN" in arg for arg in args]
 
 def get_auth_args_from_process() -> Union[List[str], None]:
-    rl_running, process = is_process_running('RocketLeague.exe', 'RocketLeague.exe', set())
-    if rl_running:
+    process = get_process('RocketLeague.exe', 'RocketLeague.exe', set())
+    if process is not None:
         try:
             all_args = process.cmdline()
         except psutil.NoSuchProcess:
@@ -67,8 +67,8 @@ def get_auth_args_from_process() -> Union[List[str], None]:
 
 def get_auth_args_from_logs() -> Union[List[str], None]:
     # Log: Command line: -AUTH_LOGIN=unused -AUTH_PASSWORD=f7a32f56ea -AUTH_TYPE=exchangecode -epicapp=Sugar -epicenv=Prod -EpicPortal  -epicusername="tare-hart" -epicuserid=41276a00c2c54f -epiclocale=en -epicsandboxid=9773aa1aa54f4f
-    rl_running, process = is_process_running('RocketLeague.exe', 'RocketLeague.exe', set())
-    if rl_running:
+    process = get_process('RocketLeague.exe', 'RocketLeague.exe', set())
+    if process is not None:
         log_file = get_rocket_league_log_path()
         if log_file.exists():
             log_text = log_file.read_text()
@@ -94,8 +94,8 @@ def launch_with_epic_login_trick(ideal_args: List[str]) -> bool:
         process = None
         while True:
             sleep(1)
-            rl_running, process = is_process_running('RocketLeague.exe', 'RocketLeague.exe', set())
-            if rl_running:
+            process = get_process('RocketLeague.exe', 'RocketLeague.exe', set())
+            if process is not None:
                 break
             logger.info("Waiting for RocketLeague.exe to start...")
 

--- a/src/main/python/rlbot/utils/process_configuration.py
+++ b/src/main/python/rlbot/utils/process_configuration.py
@@ -91,7 +91,7 @@ def extract_all_pids(agent_metadata_map):
     return pids
 
 
-def is_process_running(program, scriptname, required_args: Set[str]) -> Tuple[bool, Union[psutil.Process, None]]:
+def get_process(program, scriptname, required_args: Set[str]) -> Union[psutil.Process, None]:
     # Find processes which contain the program or script name.
     matching_processes = []
     for process in psutil.process_iter():
@@ -114,7 +114,7 @@ def is_process_running(program, scriptname, required_args: Set[str]) -> Tuple[bo
                         break
                 else:
                     # If this process has not been skipped, it matches all arguments.
-                    return True, process
+                    return process
                 mismatch_found = True
             except psutil.AccessDenied:
                 print(f"Access denied when trying to look at cmdline of {process}!")
@@ -125,8 +125,13 @@ def is_process_running(program, scriptname, required_args: Set[str]) -> Tuple[bo
             # If we didn't return yet it means all matching programs were skipped.
             raise WrongProcessArgs(f"{program} is not running with required arguments: {required_args}!")
     # No matching processes.
-    return False, None
+    return None
 
+
+def is_process_running(program, scriptname, required_args: Set[str]) -> Tuple[bool, Union[psutil.Process, None]]:
+    process = get_process(program, scriptname, required_args)
+    return process is not None, process
+    
 
 class WrongProcessArgs(UserWarning):
     pass


### PR DESCRIPTION
Error can occur if the process dies between when we first saw it and grabbed the args, and then when we go to kill it where we were looking for the process via iterating all processes again and assuming success.

Fix removes the second iterating, as to reach this point we have already succeeded. If the process has already been killed we will no longer error as we can call `kill` on an already dead process without error. 
In the case it did die to have reached this point we did see it and did get the args, so no reason not to push ahead regardless.

Also includes a refactor - the is_process_running returned a bool and a process/None. It was being used in a way where the bool would be checked and then assume the process is not None based on the bool. If the bool and process is always guaranteed to be tied why return both. If there is a case where one can envisage the bool and process not being coupled in that way then existing use cases will break. The refactor removes the chance for the ambiguity. Refactor has a new function name, old one is still kept for backwards compatibility.