### PR TITLE
Fixed bug in last commit

### DIFF
--- a/src/main/python/rlbot/gamelaunch/epic_launch.py
+++ b/src/main/python/rlbot/gamelaunch/epic_launch.py
@@ -109,7 +109,13 @@ def launch_with_epic_login_trick(ideal_args: List[str]) -> bool:
             time.sleep(1)
             logger.info("Waiting for Rocket League args...")
 
-        process.kill()
+        process = get_process('RocketLeague.exe', 'RocketLeague.exe', set())
+        if process:
+            try:
+                process.kill()
+            except psutil.NoSuchProcess:
+                # the process killed itself before we did, but result is the same.
+                pass
         modified_args = ideal_args + all_args
         logger.info(f"Killed old rocket league, reopening with {modified_args}")
         launch_with_epic_simple(modified_args)


### PR DESCRIPTION
Last commit not working for some, the process variable can be holding the original or restarted RL exe.

This now reverts that assumption. Instead just targets the issue the user was having with 1.62.3 where the process did not exist (so it was trying to call 'kill' on None). Instead we check that it is not None, and then also handle the case that the process may die before we kill it.

Still unsure why the RL would have dies for that user, (perhaps they had killed it?) but this fix still should give the intended outcome of the last fix: we have the args, the fact the process has dies outside of our control is OK as we have enough to continue.