### PR TITLE
Avoiding ghost inputs and failed bot starts when using training.

### DIFF
--- a/src/main/python/rlbot/botmanager/agent_metadata.py
+++ b/src/main/python/rlbot/botmanager/agent_metadata.py
@@ -11,7 +11,7 @@ class AgentMetadata:
                  helper_process_request: HelperProcessRequest = None):
         """
         :param index: The player index, i.e. "this is player number <index>".
-        :param name: The agent's name.
+        :param name: The agent's name. This is the deduped name, e.g. if there are multiple of the bot it may be MyBot (2)
         :param team: 0 for blue team or 1 for orange team.
         :param pids: A list all the process ids that this bot uses (including the ones inside the python process).
         :param helper_process_request: A helper process which can be shared, e.g. with other bots of the same type.

--- a/src/main/python/rlbot/socket/socket_manager.py
+++ b/src/main/python/rlbot/socket/socket_manager.py
@@ -23,6 +23,8 @@ from rlbot.messages.flat.PlayerStatEvent import PlayerStatEvent
 from rlbot.messages.flat.QuickChat import QuickChat
 from rlbot.utils.logging_utils import get_logger
 
+# We can connect to RLBot.exe on this port.
+RLBOT_SOCKETS_PORT = 23234
 
 class SocketDataType(IntEnum):
     GAME_TICK_PACKET = 1
@@ -113,14 +115,14 @@ class SocketRelay:
         self.socket.settimeout(self.connection_timeout)
         for i in range(int(self.connection_timeout * 10)):
             try:
-                self.socket.connect(('127.0.0.1', 23234))
+                self.socket.connect(('127.0.0.1', RLBOT_SOCKETS_PORT))
                 break
             except ConnectionRefusedError:
                 sleep(.1)
 
         self.socket.settimeout(None)
         self.is_connected = True
-        self.logger.info("Connected!")
+        self.logger.info(f"Socket manager connected to port {RLBOT_SOCKETS_PORT} from port {self.socket.getsockname()[1]}!")
         for handler in self.on_connect_handlers:
             handler()
 


### PR DESCRIPTION
The main part of this change is to take more care with `agent_metadata_queue`. Messages in that queue can start bots if they contain a helper process request, so it's very bad if messages from a previous match carry over to the next match somehow. Even if the bots from the previous match were properly shut down or killed, they'll be started again and cause "ghost inputs" where more than one bot process is trying to control the same bot index.

This was impacting non-python bots that rely on the helper process system, e.g. Scratch, C#, Java (and of course any bot can be impacted by the subsequent ghost inputs).

While I was in there, I made some other changes to make the training system work better for the purposes of AutoLeague type programs.