### PR TITLE
Processing agent metadata during training, registering child processes.

### DIFF
--- a/src/main/python/rlbot/setup_manager.py
+++ b/src/main/python/rlbot/setup_manager.py
@@ -640,7 +640,15 @@ class SetupManager:
                 process_configuration.configure_processes(self.agent_metadata_map, self.logger)
             except queue.Empty:
                 self.num_metadata_received += num_recieved
-                return num_recieved
+                break
+
+        # Let's go through the agent metadata map and see if we can expand it with any child processes.
+        # We'll do it every time this function is called (generall periodically),
+        # we don't know when an agent might spawn another process.
+        if process_configuration.append_child_pids(self.agent_metadata_map):
+            process_configuration.configure_processes(self.agent_metadata_map, self.logger)
+
+        return num_recieved
 
     def reload_all_agents(self, quiet=False):
         if not quiet:

--- a/src/main/python/rlbot/utils/rate_limiter.py
+++ b/src/main/python/rlbot/utils/rate_limiter.py
@@ -12,14 +12,22 @@ class RateLimiter:
     # Assumes acquring 1 permit
     def acquire(self):
         while True:
-            now = time.perf_counter()
-            self.accumulator += now - self.then
-            self.then = now
-            if self.accumulator > self.time_per_tick:
-                self.accumulator -= self.time_per_tick
+            if self.acquire_if_ready():
                 break
             else:
                 time.sleep(0.002)
+
+    def acquire_if_ready(self) -> bool:
+        """
+        A non-blocking check to see if the next tick is ready now.
+        """
+        now = time.perf_counter()
+        self.accumulator += now - self.then
+        self.then = now
+        if self.accumulator > self.time_per_tick:
+            self.accumulator -= self.time_per_tick
+            return True
+        return False
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
RLBot tries to constrain each bot to a specific set of CPU cores for fairness. There was a gap in this system where a bot can spawn a child process that can use ALL cores. This is a huge advantage because the bot gets more processing power, and robs processing power from the opponent.

Now we'll periodically check for child processes that may not have been reported, and constrain them to the right cores.