### PR TITLE
Fix launching bots with venvs on non-windows

### DIFF
--- a/src/main/python/rlbot/setup_manager.py
+++ b/src/main/python/rlbot/setup_manager.py
@@ -501,7 +501,10 @@ class SetupManager:
                 if bundle.supports_standalone:
                     executable = sys.executable
                     if bundle.use_virtual_environment:
-                        executable = str(Path(bundle.config_directory) / 'venv' / 'Scripts' / 'python.exe')
+                        if platform.system() == "Windows":
+                            executable = str(Path(bundle.config_directory) / 'venv' / 'Scripts' / 'python.exe')
+                        else:
+                            executable = str(Path(bundle.config_directory) / 'venv' / 'bin' / 'python')
                     process = subprocess.Popen([
                         executable,
                         bundle.python_file,


### PR DESCRIPTION
If a bot utilized a virtual environment, then it just wouldn't launch if the user wasn't on Windows. This, at least, should work on Windows.