### PR TITLE
Add a launcher preference for epic_only, without steam fallback

### DIFF
--- a/src/main/python/rlbot/gamelaunch/epic_launch.py
+++ b/src/main/python/rlbot/gamelaunch/epic_launch.py
@@ -85,7 +85,7 @@ def get_auth_args_from_logs() -> Union[List[str], None]:
                     return all_args
     return None
 
-def launch_with_epic_login_trick(ideal_args: List[str], launcher_preference) -> bool:
+def launch_with_epic_login_trick(ideal_args: List[str], launcher_preference = None) -> bool:
     """
     This needs to fail gracefully! Sometimes people only have the Steam version,
     so we want to be able to fall back to Steam if Epic is going nowhere.


### PR DESCRIPTION
Currently we accept launcher preferences for steam vs epic. The steam choice tries steam only. The epic choice tries epic, and then falls back to steam if that fails, which causes a large amount of confusion and misery for our users.

Adding a new option (for backwards compatibility) called epic_only that does NOT fall back to steam. A separate change to RLBotGUI can rename the UI options to match the actual behaviors.

Also adding an input that RLBotGUI could use later to set the location of the Epic RocketLeague.exe file.