### PR TITLE
Fix psutil version pin

### DIFF
--- a/src/main/python/setup.py
+++ b/src/main/python/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         'flatbuffers==1.12',
-        'psutil==5.8.0',
+        'psutil==5.*',
         'inputs',
         'websockets',
         'dataclasses',  # Python 3.6 compatibility


### PR DESCRIPTION
5.8 doesn't support Python 3.11